### PR TITLE
Make the code more developer friendly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-
 torntools/todo.txt
 torntools/scripts/content/casino/ttKeno.js
 torntools/personalized.js
+
+# IDE Settings
+.idea

--- a/torntools/manifest.json
+++ b/torntools/manifest.json
@@ -31,6 +31,11 @@
 	"options_ui": {
 		"page": "views/settings/settings.html"
 	},
+	"browser_specific_settings": {
+		"gecko": {
+			"id": "torntools@mephiles.github.com"
+		}
+	},
 	"content_scripts": [
 		{
 			"matches": [


### PR DESCRIPTION
The updated .gitignore will allow developers to use IntelliJ IDEA as IDE.
The updated manifest file will make it so the extension has a proper extension id so multiple installations will be recognized as one (at least on part of the settings).