### PR TITLE
Issue #214: Fix hide chat hidden by chats

### DIFF
--- a/torntools/changelog.js
+++ b/torntools/changelog.js
@@ -6,6 +6,7 @@ export default {
 		"Fixes": [
 			"Properly display item values for weapons and other single items. - DKK",
 			"Fix chain notifications going out too early. - DKK",
+			"Fix hide chat hidden by chats. - finally",
 		],
 		"Changes": [
 			"Added sell points award and refill award trackers. - wootty2000",

--- a/torntools/scripts/content/global/ttGlobal.css
+++ b/torntools/scripts/content/global/ttGlobal.css
@@ -573,7 +573,7 @@ div[role='main'].tt-modified {
     height: 40px;
     width: 48px;
     position: fixed;
-    left: 0;
+    left: 5px;
     bottom: 0;
     z-index: 999;
 

--- a/torntools/scripts/content/global/ttGlobal.js
+++ b/torntools/scripts/content/global/ttGlobal.js
@@ -484,7 +484,18 @@ function showToggleChat() {
 		ttStorage.set({ settings: settings });
 	});
 
+	function setToggleChatPosition() {
+		var maxTop = Array.from(document.querySelectorAll("#chatRoot > div > div")).reduce((accumulator, currentValue) => Math.max(accumulator || 0, currentValue.style["top"].replace(/[^\d]/g, ""))) || 0;
+		var iconBottom = ((maxTop / 39 / 2) + 1) * 39;
+
+		icon.style["bottom"] = `${iconBottom}px`;
+	}
+
+	new MutationObserver(() => setToggleChatPosition()).observe(document.querySelector("#chatRoot > div"), {attributes:true, subtree:true});
+
 	doc.find("#body").prepend(icon);
+
+	setToggleChatPosition();
 }
 
 function addInformationSection() {


### PR DESCRIPTION
At first I tried to add the toggle button as an element to the chat-box list, but adding your own elements to that list screws with the positioning of the other elements, since the torn script is not aware of that new element, and this sometimes resulted in overlapping elements.