### PR TITLE
Issue #54: Fix icon margin on dynamic change

### DIFF
--- a/torntools/changelog.js
+++ b/torntools/changelog.js
@@ -6,6 +6,7 @@ export default {
 		"Fixes": [
 			"Properly display item values for weapons and other single items. - DKK",
 			"Fix chain notifications going out too early. - DKK",
+			"Fix icon margin on dynamic change. - finally",
 		],
 		"Changes": [
 			"Added sell points award and refill award trackers. - wootty2000",

--- a/torntools/scripts/content/global/ttGlobal.js
+++ b/torntools/scripts/content/global/ttGlobal.js
@@ -70,12 +70,20 @@ requireDatabase().then(() => {
 		}
 
 		// Remove icons that are hidden
-		for (let icon of doc.findAll(`#sidebarroot .status-icons___1SnOI>li`)) {
-			let name = icon.getAttribute("class").split("_")[0];
-			if (hide_icons.indexOf(name) > -1) {
-				icon.parentElement.appendChild(icon);
+		function hideIcons (observer) {
+			observer.disconnect();
+
+			for (let icon of doc.findAll("#sidebarroot .status-icons___1SnOI>li")) {
+				let name = icon.getAttribute("class").split("_")[0];
+				if (hide_icons.indexOf(name) > -1) {
+					icon.parentElement.appendChild(icon);
+				}
 			}
+
+			observer.observe(doc.find("#sidebarroot .status-icons___1SnOI"), {childList:true});
 		}
+
+		hideIcons(new MutationObserver((_, observer) => hideIcons(observer)));
 
 		// Vault balance
 		if (settings.pages.global.vault_balance && !mobile) {


### PR DESCRIPTION
Moves hidden icons to the end of the list when dynamically changed, avoiding bad margins.