### PR TITLE
Expand quick crimes when editing

### DIFF
--- a/torntools/scripts/content/crimes/ttCrimes.js
+++ b/torntools/scripts/content/crimes/ttCrimes.js
@@ -215,6 +215,7 @@ function addButton() {
 				quickCrime.classList.remove("removable");
 			}
 		} else {
+			doc.find('#ttQuick .tt-title').classList.remove('collapsed');
 			doc.find(".tt-black-overlay").classList.add("active");
 			doc.find(".tt-title .tt-options .tt-option#edit-crime-button").classList.add("tt-highlight-sector");
 


### PR DESCRIPTION
When a user edits the quick crimes, if the bar is collapsed, it may not be obvious that the crimes are being added. I spent about 1-2 mins as a user wondering if the new extension I installed wasn't adding crimes correctly ;)

Solution initially was to refactor the container generation in `content` to add a toggle function so it would be easy to generically toggle any collapsible container box. Instead, a simpler solution was to collapse the box directly. A bit leaky, but this behaviour is so far specific to the crimes box.

Additionally, I chose not to fire the `storage` event for `container_open` (which seems backwards in how it's used, btw[0]), since it's a purely cosmetic change whilst editing and we don't need to persist the state of the box.

[0] `container_open` suggests that true/false would mean !collapsed/collapsed. Instead, when we fire the event, the `collapsed` value is inverted https://github.com/Mephiles/torntools_extension/blob/master/torntools/scripts/js/globalFunctions.js#L1958. So `collapsed == true` means `container_open: true`. 