### PR TITLE
Fix 'Three-peat' mission hint

### DIFF
--- a/torntools/changelog.js
+++ b/torntools/changelog.js
@@ -1,7 +1,10 @@
 export default {
 	"v5.3.xxx - xxth. 2020": {
 		Features: [],
-		Fixes: ["Fix Achievement check by including medals/honors. - finally"],
+		Fixes: [
+			"Fix Achievement check by including medals/honors. - finally",
+			"Fix 'Three-peat' mission hints. - smikula"
+		],
 		Changes: [],
 	},
 	"v5.3 - October, 16th. 2020": {

--- a/torntools/scripts/content/missions/ttMissions.js
+++ b/torntools/scripts/content/missions/ttMissions.js
@@ -193,7 +193,7 @@ const MISSIONS = {
 		task: "Defeat (P) using only a slashing or piercing weapon.",
 		hint: "Equip only a slashing or piercing weapon, armor can remain equipped.",
 	},
-	"Three-Peat": { task: "Defeat any 3 players by leave 1, mug 1 and hosp 1." },
+	"Three-peat": { task: "Defeat any 3 players by leave 1, mug 1 and hosp 1." },
 	"Training Day": { task: "Spend 250e/500e/750e/1000e/1250e gym training." },
 	"Tree Huggers": { task: "Defeat 6-8 (P)." },
 	Undercutters: { task: "Defeat 3 (P)." },


### PR DESCRIPTION
Looks like it was probably a simple casing issue.