### PR TITLE
Change Idolised to Idolized

### DIFF
--- a/torntools/scripts/js/globalFunctions.js
+++ b/torntools/scripts/js/globalFunctions.js
@@ -1645,7 +1645,7 @@ const RANKS = {
 	Outstanding: 18,
 	Celebrity: 19,
 	Supreme: 20,
-	Idolised: 21,
+	Idolized: 21,
 	Champion: 22,
 	Heroic: 23,
 	Legendary: 24,


### PR DESCRIPTION
Problem: players with rank Idolized were not showing stat estimates.

Stat estimation, among other things, are affected by this typo.

Issue found and suggested fix by GuruSteve.