### PR TITLE
Fixed bug where quick crimes would not work if crimes was opened in a new tab

### DIFF
--- a/torntools/scripts/content/crimes/ttCrimes.js
+++ b/torntools/scripts/content/crimes/ttCrimes.js
@@ -24,6 +24,7 @@ requireDatabase().then(() => {
 		showCrimesContainer(quick);
 
 		crimesLoaded().then(() => {
+			toggleCrimes();
 			markCrimes();
 		});
 
@@ -43,6 +44,7 @@ requireDatabase().then(() => {
 			});
 
 			crimesLoaded().then(() => {
+				toggleCrimes();
 				markCrimes();
 			});
 		});
@@ -141,7 +143,7 @@ function markCrimes() {
 function crimesLoaded() {
 	return new Promise((resolve) => {
 		let checker = setInterval(() => {
-			if ([...doc.findAll("form[name=crimes]>ul>li")].length > 1) {
+			if ([...doc.findAll("form[name=crimes]>ul>li")].length > 1 && doc.find("#user-money")) {
 				resolve(true);
 				return clearInterval(checker);
 			}
@@ -186,8 +188,6 @@ function showCrimesContainer(quick) {
 	});
 
 	doc.find("#ttQuick .tt-options").appendChild(safeWrap);
-
-	toggleCrimes();
 
 	safeSetting.checked = filters.crimes.safeCrimes;
 	document.documentElement.style.setProperty("--torntools-only-safe-crimes", filters.crimes.safeCrimes ? "none" : "block");


### PR DESCRIPTION
The behavior before this patch would not allow quick crimes to work if a user
visited https://www.torn.com/crimes.php#/step=main from a non-torn site.
The user's money would load before crimes and we'd get an Uncaught TypeError

After this patch, crimesLoaded() checks for whether the user's money has loaded too.
We now wait to toggleCrimes() until crimesLoaded() is done

Bug: https://github.com/Mephiles/torntools_extension/issues/341

Video of fix working:
https://i.imgur.com/hAT2BrB.mp4