### PR TITLE
Fix duplicate DOM id's causing address suggestions on chrome

### DIFF
--- a/torntools/changelog.js
+++ b/torntools/changelog.js
@@ -1,8 +1,16 @@
 export default {
 	"v5.7 - xxxxxx, xx. 2021": {
 		Features: ["Add option to export War Report as CSV. - Sashank999", "Show end time of Wars on faction pages. - Sashank999"],
-		Fixes: ["Don't show the attack warning on attack logs. - Sashank999", "Fix achievements section not showing. - Sashank999", "Show a warning when you try to train while stacking. - Sashank999",],
-		Changes: ["Only highlight chain timers over a configurable amount. - Sashank999", "Add 'I'm Chaining' button to stop warning for 30 minutes on Attack Page. - Sashank999"],
+		Fixes: [
+			"Don't show the attack warning on attack logs. - Sashank999",
+			"Fix achievements section not showing. - Sashank999",
+			"Show a warning when you try to train while stacking. - Sashank999",
+			"Fix an interaction between chrome, torn tools, the faction page, that would cause chrome to suggest addresses in the chat box. - WizardRubic",
+		],
+		Changes: [
+			"Only highlight chain timers over a configurable amount. - Sashank999",
+			"Add 'I'm Chaining' button to stop warning for 30 minutes on Attack Page. - Sashank999",
+		],
 	},
 	"v5.6.1 - January, xxth. 2021": {
 		Fixes: [

--- a/torntools/scripts/content/global/ttGlobal.js
+++ b/torntools/scripts/content/global/ttGlobal.js
@@ -380,7 +380,7 @@ function addChatFilters() {
 
 		let filter_wrap = doc.new({ type: "div", class: "tt-chat-filter" });
 		let filter_text = doc.new({ type: "div", text: "Find:" });
-		let filter_input = doc.new({ type: "input", id: "---search---" });
+		let filter_input = doc.new({ type: "input" });
 
 		filter_wrap.appendChild(filter_text);
 		filter_wrap.appendChild(filter_input);
@@ -761,7 +761,7 @@ function addPeopleBoxFilter() {
 
 		let filter_wrap = doc.new({ type: "div", class: "tt-chat-filter" });
 		let filter_text = doc.new({ type: "div", text: "Find:" });
-		let filter_input = doc.new({ type: "input", id: "---search---" });
+		let filter_input = doc.new({ type: "input" });
 
 		filter_wrap.appendChild(filter_text);
 		filter_wrap.appendChild(filter_input);


### PR DESCRIPTION
When on Chrome, if viewing the below page with torn tools:
https://www.torn.com/factions.php?step=your#/
With chrome's save and fill addresses setting ticked:
chrome://settings/addresses
Chrome would suggest an address into the chat boxes.

Also, the below error message would pop up:
[DOM] Found 2 elements with non-unique id #---search---: (More info: https://goo.gl/9p2vKq) <input id="---search---">

This changes renames both instances of the offending duplicated DOM id.
This stops chrome from suggesting an address.

Bug: #382