### PR TITLE
formatDateObject()

### DIFF
--- a/torntools/scripts/content/bank/ttBank.js
+++ b/torntools/scripts/content/bank/ttBank.js
@@ -105,8 +105,6 @@ async function showTable() {
 }
 
 function showInvestmentOverTime() {
-	let overDate = new Date(new Date().setSeconds(userdata.city_bank.time_left));
-	let formattedDate = formatDate([overDate.getDate(), overDate.getMonth() + 1, overDate.getFullYear()], settings.format.date);
-	let formattedTime = formatTime([overDate.getHours(), overDate.getMinutes(), overDate.getSeconds()], settings.format.time);
-	doc.find("p.m-clear").insertAdjacentHTML("afterEnd", `<span>Investment will be completed on <b>${formattedDate} ${formattedTime}</b></span>`);
+	let overDate = formatDateObject(new Date(new Date().setSeconds(userdata.city_bank.time_left)));
+	doc.find("p.m-clear").insertAdjacentHTML("afterEnd", `<span>Investment will be completed on <b>${overDate.formattedDate} ${overDate.formattedTime}</b></span>`);
 }

--- a/torntools/scripts/content/education/ttEducation.js
+++ b/torntools/scripts/content/education/ttEducation.js
@@ -15,8 +15,6 @@ function hideCompletedCategories() {
 }
 
 function showEducationCourseOverTime() {
-	let overDate = new Date(new Date().setSeconds(userdata.education_timeleft));
-	let formattedDate = formatDate([overDate.getDate(), overDate.getMonth() + 1, overDate.getFullYear()], settings.format.date);
-	let formattedTime = formatTime([overDate.getHours(), overDate.getMinutes(), overDate.getSeconds()], settings.format.time);
-	doc.find("div.msg.right-round span.bold.hasCountdown").insertAdjacentHTML("afterEnd", `<span>&nbsp;<b>(${formattedDate} ${formattedTime})</b></span>`);
+	let overDate = formatDateObject(new Date(new Date().setSeconds(userdata.education_timeleft)));
+	doc.find("div.msg.right-round span.bold.hasCountdown").insertAdjacentHTML("afterEnd", `<span>&nbsp;<b>(${overDate.formattedDate} ${overDate.formattedTime})</b></span>`);
 }

--- a/torntools/scripts/js/globalFunctions.js
+++ b/torntools/scripts/js/globalFunctions.js
@@ -3175,6 +3175,12 @@ function cacheEstimate(userId, timestamp, estimate, lastAction) {
 	});
 }
 
+function formatDateObject(givenDate) {
+	let formattedDate = formatDate([givenDate.getDate(), givenDate.getMonth() + 1, givenDate.getFullYear()], settings.format.date);
+	let formattedTime = formatTime([givenDate.getHours(), givenDate.getMinutes(), givenDate.getSeconds()], settings.format.time);
+	return {formattedDate, formattedTime};
+}
+
 function fetchApi_v2(
 	location,
 	options = {


### PR DESCRIPTION
Crete new function to reduce JS `Date` objects into normal time format with the settings formatting and use `formatDate()` and `formatTime()` automatically.