### PR TITLE
Run prettier automatically

### DIFF
--- a/.github/workflows/run-prettier.yml
+++ b/.github/workflows/run-prettier.yml
@@ -1,0 +1,20 @@
+name: Run Prettier
+on:
+    push:
+        branches: [master]
+    pull_request:
+        branches: [master]
+    workflow_dispatch:
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            # Downloads Repos for Usage
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v1
+
+            # Runs prettier
+            - name: Format with prettier
+              run: |
+                  npm i prettier
+                  npx prettier --write .


### PR DESCRIPTION
This file makes every push and pull request merge run Prettier automatically.

In case you want to do it manually, there is also an option in the Github's Actions Section and under the name "Run Prettier", select branch and run it.

By default, it runs only on master branch.

It uses configuration already in the github repo.  Changing the prettier configuration changes its way too.

In YAML, tabs shouldn't be used. I ran prettier on this but it didn't add the tabs to it. Tabs in YAML causes issues.