### PR TITLE
Update run-prettier.yml

### DIFF
--- a/.github/workflows/run-prettier.yml
+++ b/.github/workflows/run-prettier.yml
@@ -2,9 +2,6 @@ name: Run Prettier
 on:
     push:
         branches: [master]
-    pull_request:
-        branches: [master]
-        types: [opened]
     workflow_dispatch:
 jobs:
     build:


### PR DESCRIPTION
Github Actions work on the user's repo only and not on the forks or other repos from which PRs are opened.

Prettier already runs when PR is merged, so no worries.