### PR TITLE
Fix deck initialization in High-Low helper

### DIFF
--- a/torntools/changelog.json
+++ b/torntools/changelog.json
@@ -4,7 +4,8 @@
 		"Fixes": [
 			"Apply proper rounding on the racing winning rate. - Sashank999",
 			"Fix max buy on mobile. - DKK",
-			"TT Settings Sidebar link not going down when hosped or jailed. - Sashank999"
+			"TT Settings Sidebar link not going down when hosped or jailed. - Sashank999",
+			"Fix probability calculation in HiLo helper. - smikula"
 		],
 		"Changes": ["Disable loot timers on mobile devices. - Sashank999"]
 	},

--- a/torntools/scripts/content/casino/ttHiLo.js
+++ b/torntools/scripts/content/casino/ttHiLo.js
@@ -16,12 +16,7 @@ function Main() {
 		A: 14,
 	};
 
-	let current_deck = {
-		hearts: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-		diamonds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-		clubs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-		spades: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-	};
+	let current_deck = getNewDeck();
 	let last_dealer_card;
 	let last_you_card;
 	let cashed_in = false;
@@ -44,20 +39,10 @@ function Main() {
 			console.log("Lost");
 			last_dealer_card = undefined;
 			last_you_card = undefined;
-			current_deck = {
-				hearts: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-				diamonds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-				clubs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-				spades: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-			};
+			current_deck = getNewDeck();
 		} else if (doc.find(".deck-wrap").style.display === "block") {
 			console.log("Deck shuffled");
-			current_deck = {
-				hearts: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-				diamonds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-				clubs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-				spades: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-			};
+			current_deck = getNewDeck();
 			setTimeout(calculate, 700);
 		} else {
 			setTimeout(calculate, 700);
@@ -71,12 +56,7 @@ function Main() {
 		cashed_in = true;
 		last_dealer_card = undefined;
 		last_you_card = undefined;
-		current_deck = {
-			hearts: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-			diamonds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-			clubs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-			spades: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-		};
+		current_deck = getNewDeck();
 	});
 
 	// remove action when chosen option
@@ -192,4 +172,13 @@ function getAction(deck, _card) {
 
 function casinoGameLoaded() {
 	return requireElement("div.startGame").then((data) => data);
+}
+
+function getNewDeck() {
+	return {
+		hearts: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+		diamonds: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+		clubs: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+		spades: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+	}
 }


### PR DESCRIPTION
I'd love a sanity check on my logic here, but I'm pretty sure my change is fixing a bug.  The initial deck includes cards for each suit as `[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]`.  An ace is represented by `14`.  There is no `1` card.  So having this in the deck biases the probability towards picking "lower" when this isn't always correct.

I'm removing the 1's, and I also factor the deck initialization into a `getNewDeck` function rather than duplicating it multiple times in the file.