### PR TITLE
Chain CSV names

### DIFF
--- a/extension/scripts/global/functions/torn.js
+++ b/extension/scripts/global/functions/torn.js
@@ -1706,9 +1706,10 @@ function getUsername(row) {
 	} else {
 		const link = row.find("a[href*='profiles']");
 		if (link.getAttribute("id")) {
-			name = "";
+			name = link.find("span").textContent || "";
 			id = link.getAttribute("id").split("-")[0].getNumber();
-			combined = id;
+
+			combined = name ? `${name} [${id}]` : id;
 		} else {
 			name = link.textContent;
 			id = link.href.match(/XID=([0-9]*)/i)[1].getNumber();


### PR DESCRIPTION
Show names in chain CSV again after Torn removed them from the page.