### PR TITLE
Fix Chat Font Size.

### DIFF
--- a/extension/scripts/features/font-size/ttFontSize.css
+++ b/extension/scripts/features/font-size/ttFontSize.css
@@ -1,3 +1,3 @@
-#chatRoot div[class^="overview_"] div[class^="message_"] * {
+#chatRoot div[class*="overview_"] div[class*="message_"] * {
 	font-size: var(--torntools-chat-font-size, 12px) !important;
 }


### PR DESCRIPTION
Fixed the bug caused due to Torn HTML using classes with prefixed `_` in `#chatRoot`.