### PR TITLE
Fix open in new tab checkbox in sidebar custom links not displaying correct settings

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -9,6 +9,10 @@
 				{
 					"message": "Fix NPC loot times not showing when YATA is disabled, even when using TS for it.",
 					"contributor": "DeKleineKobini"
+				},
+				{
+					"message": "Fix open in new tab settings in sidebar custom links not saving properly.",
+					"contributor": "josephting"
 				}
 			],
 			"changes": [

--- a/extension/pages/settings/settings.js
+++ b/extension/pages/settings/settings.js
@@ -776,7 +776,18 @@ async function setupPreferences(requireCleanup) {
 		const newRow = document.newElement({
 			type: "li",
 			children: [
-				document.newElement({ type: "input", class: "newTab", attributes: { type: "checkbox" } }),
+				document.newElement({
+					type: "input",
+					class: "newTab",
+					attributes: {
+						type: "checkbox",
+						...(data.newTab
+							? {
+									checked: true,
+							  }
+							: {}),
+					},
+				}),
 				document.newElement({
 					type: "select",
 					class: "preset",


### PR DESCRIPTION
This was discovered and reported by [DONCIC [2018849]](https://www.torn.com/profiles.php?XID=2018849).

`/pages/settings/settings.html?page=preferences&section=sidebar` (Custom Links section)

The "open in new tab" checkboxes of saved custom links always displays as unchecked when loading the settings page. Custom links opens in new tab properly after checking the boxes and save the settings, until settings is saved next without having these checkboxes checked (making other setting changes).

![image](https://user-images.githubusercontent.com/1507016/183441227-3a56a479-eb14-4553-bd1f-04e1e3d5859e.png)

## Steps to reproduce

1. Add custom links with open in new tab in torntools preferences; save preferences
2. Refresh torntools preferences (can confirm checkbox is unchecked)
3. At this point, the custom link added opens in a new tab
4. Open torntools preferences page, change General -> Time to 12 hours or 24 hours (the currently unselected one) or any other settings to enable saving; save preferences
5. The custom link that opened in a new tab at (3) no longer opens in a new tab
