### PR TITLE
Fix highlight properties type error.

### DIFF
--- a/extension/scripts/features/highlight-properties/ttHighlightProperties.js
+++ b/extension/scripts/features/highlight-properties/ttHighlightProperties.js
@@ -29,9 +29,9 @@
 		if (Math.abs(userdata.networth.unpaidfees) >= settings.pages.sidebar.upkeepPropHighlight) {
 			const navProperties = document.find("#nav-properties");
 
-			if (navProperties) {
-				navProperties.classList.add("tt-upkeep");
-			}
+			if (!navProperties) return;
+
+			navProperties.classList.add("tt-upkeep");
 		}
 	}
 

--- a/extension/scripts/features/highlight-properties/ttHighlightProperties.js
+++ b/extension/scripts/features/highlight-properties/ttHighlightProperties.js
@@ -26,7 +26,13 @@
 	async function addHighlight() {
 		await requireSidebar();
 
-		if (Math.abs(userdata.networth.unpaidfees) >= settings.pages.sidebar.upkeepPropHighlight) document.find("#nav-properties").classList.add("tt-upkeep");
+		if (Math.abs(userdata.networth.unpaidfees) >= settings.pages.sidebar.upkeepPropHighlight) {
+			const navProperties = document.find("#nav-properties");
+
+			if (navProperties) {
+				navProperties.classList.add("tt-upkeep");
+			}
+		}
 	}
 
 	function removeHighlight() {


### PR DESCRIPTION
When you have enabled "**Highlight properties link when upkeep is greater than X**" setting in the "**Sidebar**" settings, but in the same time you are traveling, the extension throws the following error:

`TypeError: Cannot read properties of null (reading 'classList')
    at addHighlight (chrome-extension://.../scripts/features/highlight-properties/ttHighlightProperties.js:29:125)`

![image](https://user-images.githubusercontent.com/116174233/196871318-6a564b4b-c116-4c79-9e3f-9189258ebc77.png)
