### PR TITLE
Fix stacking issue with profile arrow

### DIFF
--- a/extension/scripts/global/globalStyle.css
+++ b/extension/scripts/global/globalStyle.css
@@ -138,7 +138,7 @@
 	top: 5px;
 	right: calc((100vw - 976px) / 2 - 50px);
 	position: absolute;
-	z-index: 5;
+	z-index: 11;
 	overflow: hidden;
 }
 

--- a/extension/scripts/global/team.js
+++ b/extension/scripts/global/team.js
@@ -154,6 +154,13 @@ const TEAM = [
 		torn: 2243227,
 		color: "springgreen",
 	},
+	{
+		name: "Kwack",
+		title: "Developer",
+		core: false,
+		torn: 2190604,
+		color: "deeppink"
+	},
 ];
 
 const CONTRIBUTORS = TEAM.filter(({ title, color }) => title.includes("Developer") || color).reduce(


### PR DESCRIPTION
Minor fix just to patch the stacking issue at the bottom of the screenshot below (reported [here](https://canary.discord.com/channels/726572303286009978/731999041759608873/1029983515468644402))

![Screenshot showing stacking issue](https://images-ext-1.discordapp.net/external/0G0WRfZIyoOMmZRvBxu69ol5mmg87jqk29ev5D-2QaU/https/i.imgur.com/qZw3sWY.png?width=1395&height=655)

(ignore the top box, it's an old screenshot)