### PR TITLE
Show 'item' for singular city find

### DIFF
--- a/extension/scripts/features/city-items/ttCityItems.js
+++ b/extension/scripts/features/city-items/ttCityItems.js
@@ -114,12 +114,15 @@
 			function generateText() {
 				let element;
 				if (items.length > 0) {
+					let totalCount = items.map(({ count }) => count).totalSum();
 					element = document.newElement({
 						type: "p",
 						children: [
-							"There are ",
-							document.newElement({ type: "strong", text: items.map(({ count }) => count).totalSum() }),
-							" items in the city: ",
+							"There",
+							totalCount == 1 ? " is " : " are ",
+							document.newElement({ type: "strong", text: totalCount }),
+							totalCount == 1 ? " item " : " items ",
+							"in the city: ",
 						],
 					});
 

--- a/extension/scripts/features/city-items/ttCityItems.js
+++ b/extension/scripts/features/city-items/ttCityItems.js
@@ -114,14 +114,14 @@
 			function generateText() {
 				let element;
 				if (items.length > 0) {
-					let totalCount = items.map(({ count }) => count).totalSum();
+					const totalCount = items.map(({ count }) => count).totalSum();
 					element = document.newElement({
 						type: "p",
 						children: [
 							"There",
-							totalCount == 1 ? " is " : " are ",
+							totalCount === 1 ? " is " : " are ",
 							document.newElement({ type: "strong", text: totalCount }),
-							totalCount == 1 ? " item " : " items ",
+							totalCount === 1 ? " item " : " items ",
 							"in the city: ",
 						],
 					});


### PR DESCRIPTION
Didn't actually test this out yet, but fairly confident it will be fine.

Reason: to show 'There is 1 item in the city:' vs 'There are 1 items in the city:'

![Screenshot 2023-01-16 at 22 48 58](https://user-images.githubusercontent.com/105841/212829019-ca5a2783-54db-45d3-994b-0c4abdeb019f.png)
