### PR TITLE
Update ttForumMenu.css

### DIFF
--- a/extension/scripts/features/forum-menu/ttForumMenu.css
+++ b/extension/scripts/features/forum-menu/ttForumMenu.css
@@ -87,3 +87,7 @@ body.dark-mode .tt-forums-button-dropdown {
 .threads-list .tt-forums-highlight {
 	background-color: #ffdd0020;
 }
+
+ul.threads-list li.tt-forums-highlight.new {
+	background: linear-gradient(180deg, #ffdd0045, #ffdd0005);
+}

--- a/extension/scripts/features/forum-menu/ttForumMenu.css
+++ b/extension/scripts/features/forum-menu/ttForumMenu.css
@@ -88,6 +88,6 @@ body.dark-mode .tt-forums-button-dropdown {
 	background-color: #ffdd0020;
 }
 
-ul.threads-list li.tt-forums-highlight.new {
+.threads-list .tt-forums-highlight.new {
 	background: linear-gradient(180deg, #ffdd0045, #ffdd0005);
 }


### PR DESCRIPTION
Fix only read threads being highlighted. Note the colour could potentially use some work, I attempted to both (a) match the current TT highlight colour and (b) keep the 3d round effect that the unread threads have.

Visual example:
![Example in order: not-highlighted/read, highlighted/read, highlighted/unread, not-highlighted/unread](https://i.imgur.com/nJOuAph.png)