### PR TITLE
Add high-low to tutorial element

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -11,7 +11,8 @@
 			],
 			"changes": [
 				{ "message": "Reset events data when there are no new events.", "contributor": "TheFoxMan" },
-				{ "message": "Change date difference formatting logic for Age To Words feature.", "contributor": "TheFoxMan" }
+				{ "message": "Change date difference formatting logic for Age To Words feature.", "contributor": "TheFoxMan" },
+				{ "message": "Add warning that high-low helper is enabled.", "contributor": "Kwack"}
 			],
 			"removed": []
 		}

--- a/extension/scripts/features/high-low-helper/ttHighLowHelper.css
+++ b/extension/scripts/features/high-low-helper/ttHighLowHelper.css
@@ -23,3 +23,7 @@
 .highlow-main-wrap.beach .item-10 {
 	z-index: 0 !important;
 }
+
+.tt-msg {
+	color: #07a207;
+}

--- a/extension/scripts/features/high-low-helper/ttHighLowHelper.js
+++ b/extension/scripts/features/high-low-helper/ttHighLowHelper.js
@@ -9,7 +9,7 @@
 		() => settings.pages.casino.highlow,
 		initialiseHelper,
 		null,
-		removeHelper,
+		cleanup,
 		{
 			storage: ["settings.pages.casino.highlow"],
 		},
@@ -20,6 +20,25 @@
 	shuffleDeck();
 
 	function initialiseHelper() {
+		requireElement(".tutorial-cont .tutorial-desc.bottom-round").then((container) => {
+			container.innerHTML = document.newElement({
+				type: "div",
+				children: [
+					document.newElement({
+						type: "div",
+						class: "tt-msg",
+						children: [
+							document.newElement({
+								type: "span",
+								text: "High-Low Helper has been added by TornTools. If you would like to make your own selections it can be disabled in TornTools' settings.",
+							}),
+						],
+					}),
+				],
+			}).innerHTML; // Replace the tutorial text with the helper text instead of appending as the initial tutorial is too long (and unnecessary with tool enabled).
+			container.parentElement.style.display = "block"; // Force the tutorial to be shown on page load.
+		});
+
 		addXHRListener(({ detail: { page, xhr, json } }) => {
 			if (!feature.enabled()) return;
 
@@ -147,5 +166,10 @@
 			delete actions.dataset.outcome;
 			actions.find(".tt-high-low")?.remove();
 		}
+	}
+
+	function cleanup() {
+		removeHelper();
+		document.find(".tutorial-cont").style.display = "none";
 	}
 })();


### PR DESCRIPTION
I know the high-low helper was recently disabled by default, however apparently this is still not enough to prevent people questioning why they only have one button (I've seen this in unsourceable places like global or faction chats but the most recent sourceable example would be [here](https://discord.com/channels/343057854078386177/442000409419186196/1113116070266540053), on the official Torn Discord).

Anyone who has an install older than around 3 months (most users) have this feature enabled, and it's not a commonly used/known feature (in my opinion).

I know TornTools normally appends to the tutorial box rather than replace it's current content, but:
1. The default torn tutorial box is [excessively long](https://i.imgur.com/moeL3YM.png). Forcing all players to view the entire tutorial would be counterproductive
2. The tutorial of how to play high-low is essentially useless as the current implementation makes the decision for you

I'm happy to consider an alternative approach to this if anyone is able to think of something better, but this was the best I could think of. Or would it make more sense to display both responses and just center the first response, rather than manually remove both? 