### PR TITLE
Early Discharge filtering

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -4,7 +4,7 @@
 		"title": "Beta",
 		"date": false,
 		"logs": {
-			"features": [],
+			"features": [{ "message": "Added filtering against Early Discharge status to the userlist page.", "contributor": "Vrasp" }],
 			"fixes": [{ "message": "Fix melee Item Values overlapping in tablet mode.", "contributor": "TheFoxMan" }],
 			"changes": [
 				{ "message": "Extend Drug Details to regular item market browsing.", "contributor": "TheFoxMan" },

--- a/extension/scripts/features/userlist-filter/ttUserlistFilter.js
+++ b/extension/scripts/features/userlist-filter/ttUserlistFilter.js
@@ -63,7 +63,7 @@
 
 		const specialFilter = createFilterSection({
 			title: "Special",
-			ynCheckboxes: ["Fedded", "Fallen", "Traveling", "New Player", "On Wall", "In Company", "In Faction", "Is Donator", "In Hospital", "In Jail"],
+			ynCheckboxes: ["Fedded", "Fallen", "Traveling", "New Player", "On Wall", "In Company", "In Faction", "Is Donator", "In Hospital", "In Jail", "Early Discharge"],
 			defaults: filters.userlist.special,
 			callback: () => filtering(true),
 		});

--- a/extension/scripts/global/functions/torn.js
+++ b/extension/scripts/global/functions/torn.js
@@ -1326,6 +1326,7 @@ const SPECIAL_FILTER_ICONS = {
 	inHospital: ["icon15"],
 	inJail: ["icon16"],
 	fallen: ["icon77"],
+	earlyDischarge: ["icon82"],
 };
 
 const CHAIN_BONUSES = [10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000];

--- a/extension/scripts/global/globalData.js
+++ b/extension/scripts/global/globalData.js
@@ -775,6 +775,7 @@ const DEFAULT_STORAGE = {
 				isDonator: new DefaultSetting({ type: "string", defaultValue: "both" }),
 				inHospital: new DefaultSetting({ type: "string", defaultValue: "both" }),
 				inJail: new DefaultSetting({ type: "string", defaultValue: "both" }),
+				earlyDischarge: new DefaultSetting({ type: "string", defaultValue: "both" }),
 			},
 			hospReason: {
 				attackedBy: new DefaultSetting({ type: "string", defaultValue: "both" }),


### PR DESCRIPTION
Adds filtering against Early Discharge status in the Userlist page - highly useful for reviving factions.