### PR TITLE
Add arrow to stats estimate rows

### DIFF
--- a/extension/scripts/features/stats-estimate/statsEstimate.js
+++ b/extension/scripts/features/stats-estimate/statsEstimate.js
@@ -71,7 +71,7 @@ class StatsEstimate {
 			}
 
 			if (estimate) {
-				section.textContent = `Stats Estimate: ${estimate}`;
+				section.textContent = `↑ Stats Estimate: ${estimate} ↑`;
 				if (hasFilter) row.dataset.estimate = estimate;
 
 				showLoadingPlaceholder(section, false);


### PR DESCRIPTION
This helps indicate that the estimate applies to the row above, not the row below.