### PR TITLE
Fix Gym Progress

### DIFF
--- a/extension/scripts/features/gym-progress/ttGymProgress.js
+++ b/extension/scripts/features/gym-progress/ttGymProgress.js
@@ -20,7 +20,7 @@
 			200, 500, 1000, 2000, 2750, 3000, 3500, 4000, 6000, 7000, 8000, 11000, 12420, 18000, 18100, 24140, 31260, 36610, 46640, 56520, 67775, 84535, 106305,
 		];
 
-		const currentGym = document.find("[class*='gymButton_'][class*='inProgress_']");
+		const currentGym = await requireElement("[class*='gymButton_'][class*='inProgress_']");
 		if (!currentGym) return;
 
 		const index = currentGym.id.split("-")[1] - 2;


### PR DESCRIPTION
Fix the problem that the gym process does not appear when the gym is not initialized

![ISCUW_~M@XGCIABE18VH05L](https://github.com/Mephiles/torntools_extension/assets/54923618/6e577edb-9b91-4b99-988b-d308dc17a394)
![SEKSU$(`X}4LT1Z}3K8@YPQ](https://github.com/Mephiles/torntools_extension/assets/54923618/dc9aa528-ee7b-41b4-9841-e15b7d623ced)

This bug only occurs when the network is slow.