### PR TITLE
Use child selector instead of descendant selector

### DIFF
--- a/extension/scripts/features/armory-filter/ttArmoryFilter.js
+++ b/extension/scripts/features/armory-filter/ttArmoryFilter.js
@@ -35,7 +35,7 @@
 
 		const { options, content } = createContainer("Armory Filter", {
 			class: "mt10",
-			nextElement: document.find("#faction-armoury hr"),
+			nextElement: document.find("#faction-armoury > hr"),
 			filter: true,
 		});
 

--- a/extension/scripts/features/faction-member-filter/ttFactionMemberFilter.js
+++ b/extension/scripts/features/faction-member-filter/ttFactionMemberFilter.js
@@ -59,7 +59,7 @@
 
 		const { content } = createContainer("Member Filter", {
 			class: "mt10",
-			nextElement: document.find(".faction-info-wrap .members-list"),
+			nextElement: document.find(".faction-info-wrap > .members-list"),
 			compact: true,
 			filter: true,
 		});

--- a/extension/scripts/features/faction-quick-items/ttFactionQuickItems.js
+++ b/extension/scripts/features/faction-quick-items/ttFactionQuickItems.js
@@ -65,7 +65,7 @@
 
 		const { content, options } = createContainer("Faction Quick Items", {
 			class: "mt10",
-			nextElement: document.find("#faction-armoury hr"),
+			nextElement: document.find("#faction-armoury > hr"),
 			allowDragging: true,
 			compact: true,
 		});


### PR DESCRIPTION
When injecting containers, use the more specific [child selector (`>`)](https://developer.mozilla.org/en-US/docs/Web/CSS/Child_combinator) instead of a [descendant selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Descendant_combinator) in the following features:
* armory filter
* faction member filter
* quick items

This has the benefit of increased speed and also better compatibility with other userscripts.