### PR TITLE
Add check for the reason for no planned NPC attack

### DIFF
--- a/extension/scripts/background.js
+++ b/extension/scripts/background.js
@@ -1465,9 +1465,10 @@ async function updateNPCs() {
 	async function fetchLootRangers() {
 		const data = await fetchData("lzpt", { section: "loot" });
 		const planned = data.time.clear;
+		const reason = data.time.reason;
 
 		npcs = {
-			next_update: now + TO_MILLIS.MINUTES * (planned === 0 ? 1 : 15),
+			next_update: now + TO_MILLIS.MINUTES * (planned === 0 && !reason ? 1 : 15),
 			service: "Loot Rangers",
 			targets: {},
 		};
@@ -1492,6 +1493,7 @@ async function updateNPCs() {
 		}
 
 		npcs.planned = planned === 0 ? false : planned * 1000;
+		npcs.reason = reason;
 
 		await ttStorage.set({ npcs });
 		return true;

--- a/extension/scripts/features/npc-loot-times/ttNPCLootTimes.js
+++ b/extension/scripts/features/npc-loot-times/ttNPCLootTimes.js
@@ -45,6 +45,8 @@
 					},
 				});
 				countdownTimers.push(timer);
+			} else if (npcs.reason) {
+				timer = document.newElement({ type: "span", class: "timer", text: `After ${npcs.reason}` });
 			} else {
 				timer = document.newElement({ type: "span", class: "timer", text: "Not Scheduled" });
 			}


### PR DESCRIPTION
This is a small change to add support for the (soon to be added) optional "reason" field in the lzpt loot API.

The reason is a small string that represents _why_ an attack is not scheduled and is also an indicator to not request against the API every minute.