### PR TITLE
fix: disable align-left on Cloudflare challenge pages

### DIFF
--- a/extension/scripts/features/align-left/ttAlignLeft.css
+++ b/extension/scripts/features/align-left/ttAlignLeft.css
@@ -10,3 +10,8 @@
 .tt-align-left .without-sidebar #mainContainer .content-wrapper {
 	margin-left: 20px;
 }
+
+.tt-align-left div.container:has(> div[style*="margin-top: -80px;"] > div.cf > div.iAmUnderAttack > form#challenge-form) {
+	margin-left: 0 !important;
+	justify-content: center !important;
+}


### PR DESCRIPTION
Adds an override to `features/align-left/ttAlignLeft.css` to fix Cloudflare challenge widgets appearing at the top of the page.

Before: 
![cloudflare challenge widget at top](https://github.com/Mephiles/torntools_extension/assets/32637656/5af11543-8ed5-4010-8a0c-c74d21c0e0d9)

After:
![cloudflare challenge widget at center](https://github.com/Mephiles/torntools_extension/assets/32637656/362f02e7-11bb-4278-8d04-926e1a28923c)
