### PR TITLE
Fix mini profile information not showing due to changed internal URL

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -12,7 +12,8 @@
 				{ "message": "Make `userdata` update more resilient to null-ish values.", "contributor": "TheFoxMan" },
 				{ "message": "Add Crimes 2.0 stats to Profile Box.", "contributor": "TheFoxMan" },
 				{ "message": "Make Cooldown End Timers to be on by default.", "contributor": "TheFoxMan" },
-				{ "message": "Enable detailed logs only when developer option is ticked.", "contributor": "TheFoxMan" }
+				{ "message": "Enable detailed logs only when developer option is ticked.", "contributor": "TheFoxMan" },
+				{ "message": "Fix Mini Profile last action missing.", "contributor": "Kwack" }
 			],
 			"removed": []
 		}

--- a/extension/scripts/features/mini-profile-information/ttMiniprofileInformation.js
+++ b/extension/scripts/features/mini-profile-information/ttMiniprofileInformation.js
@@ -20,12 +20,12 @@
 		addFetchListener((event) => {
 			if (!feature.enabled()) return;
 
-			const { page, json, fetch } = event.detail;
-			if (page !== "profiles") return;
+			const { page, json, fetch: { url } } = event.detail;
+			if (page !== "page") return;
 
-			const params = new URL(fetch.url).searchParams;
-			const step = params.get("step");
-			if (step !== "getMiniProfile") return;
+			const params = new URL(url).searchParams;
+			const sid = params.get("sid");
+			if (sid !== "UserMiniProfile") return;
 
 			showInformation(json);
 		});


### PR DESCRIPTION
As reported by Adobi in the discord. 

Internal URL for mini profiles changed to `https://www.torn.com/page.php?sid=UserMiniProfile&userID=xxx&rfcv=yyyy`