### PR TITLE
Added 'in a faction' filter to hosptial, jail, and travel pages

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -13,7 +13,8 @@
 				{ "message": "Add Crimes 2.0 stats to Profile Box.", "contributor": "TheFoxMan" },
 				{ "message": "Make Cooldown End Timers to be on by default.", "contributor": "TheFoxMan" },
 				{ "message": "Enable detailed logs only when developer option is ticked.", "contributor": "TheFoxMan" },
-				{ "message": "Fix Mini Profile last action missing.", "contributor": "Kwack" }
+				{ "message": "Fix Mini Profile last action missing.", "contributor": "Kwack" },
+				{ "message": "Added 'in a faction' filter to hospital, jail, and travel pages.", "contributor": "ThtAstronautGuy"}
 			],
 			"removed": []
 		}

--- a/extension/scripts/features/abroad-people-filter/ttPeopleFilter.js
+++ b/extension/scripts/features/abroad-people-filter/ttPeopleFilter.js
@@ -203,6 +203,11 @@
 					hide("faction");
 					return;
 				}
+			} else if (filters.faction == "In a faction") {
+				if (!hasFaction) {
+					hide("faction");
+					return;
+				}
 			} else {
 				if (
 					!hasFaction || // No faction

--- a/extension/scripts/features/hospital-filter/ttHospitalFilter.js
+++ b/extension/scripts/features/hospital-filter/ttHospitalFilter.js
@@ -168,8 +168,13 @@
 				? rowFaction.find(":scope > img").getAttribute("title").trim() || "N/A"
 				: rowFaction.textContent.trim();
 
-			if (faction && faction !== "No faction" && faction !== "Unknown faction") {
+			if (faction && faction !== "No faction" && faction !== "Unknown faction" && faction !== "In a faction") {
 				if (!hasFaction || factionName === "N/A" || factionName !== faction) {
+					hideRow(li);
+					continue;
+				}
+			} else if (faction == "In a faction") {
+				if (!hasFaction) {
 					hideRow(li);
 					continue;
 				}

--- a/extension/scripts/features/jail-filter/ttJailFilter.js
+++ b/extension/scripts/features/jail-filter/ttJailFilter.js
@@ -179,8 +179,13 @@
 				? rowFaction.find(":scope > img").getAttribute("title").trim() || "N/A"
 				: rowFaction.textContent.trim();
 
-			if (faction && faction !== "No faction" && faction !== "Unknown faction") {
+			if (faction && faction !== "No faction" && faction !== "Unknown faction" && faction !== "In a faction") {
 				if (!hasFaction || factionName === "N/A" || factionName !== faction) {
+					hideRow(li);
+					continue;
+				}
+			} else if (faction == "In a faction") {
+				if (!hasFaction) {
 					hideRow(li);
 					continue;
 				}

--- a/extension/scripts/global/functions/filters.js
+++ b/extension/scripts/global/functions/filters.js
@@ -13,6 +13,10 @@ const defaultFactionsItems = [
 		value: "Unknown faction",
 		description: "Unknown faction",
 	},
+	{
+		value: "In a faction",
+		description: "In a faction",
+	},
 	...(hasAPIData() && !!userdata.faction.faction_id
 		? [
 				{

--- a/extension/scripts/global/team.js
+++ b/extension/scripts/global/team.js
@@ -189,6 +189,13 @@ const TEAM = [
 		torn: 2890448,
 		color: "orange",
 	},
+	{
+		name: "ThtAstronautGuy",
+		title: "Developer",
+		core: false,
+		torn: 1977683,
+		color: "#841210",
+	}
 ];
 
 const CONTRIBUTORS = TEAM.filter(({ title, color }) => title.includes("Developer") || color).reduce(


### PR DESCRIPTION
Updated the default filters file to add in an "in a faction" option, and implemented the search on the hospital, jail, and travel pages. I have tested it on the hospital and jail pages as working, but I haven't tested it on the travel page since I do not have time to fly at the moment.

I also updated the change log, and added myself to the contributors list as required.