### PR TITLE
Changing to new Nuclear Family API backend for Revive Requests

### DIFF
--- a/extension/scripts/features/revive-request/ttReviveRequest.js
+++ b/extension/scripts/features/revive-request/ttReviveRequest.js
@@ -114,9 +114,9 @@
 
 			if (provider === "nuke") {
 				const response = await fetchData("nukefamily", {
-					section: "dev/reviveme.php",
+					section: "api/revive-request",
 					method: "POST",
-					body: { uid: id, Player: name, Faction: faction, Country: country, AppInfo: source },
+					body: { torn_player_id: id, torn_player_name: name, torn_player_country: country, app_info: source },
 					relay: true,
 					silent: true,
 					succeedOnError: true,

--- a/extension/scripts/global/functions/api.js
+++ b/extension/scripts/global/functions/api.js
@@ -14,7 +14,7 @@ const FETCH_PLATFORMS = {
 	yata: "https://yata.yt/",
 	tornstats: "https://www.tornstats.com/",
 	torntools: "https://torntools.gregork.com/",
-	nukefamily: "https://www.nukefamily.org/",
+	nukefamily: "https://nuke.family/",
 	uhc: "https://tornuhc.eu/",
 	imperium: "https://inq.mavri.dev/",
 	hela: "https://api.no1irishstig.co.uk/",


### PR DESCRIPTION
Hey, I am currently the main developer for the Nuclear Family now. I have been working to replace our old reviving system and have made a completely new site and API. 

It's really just some minor changes swapping the URLs and the names of a few parameters. So hopefully there is nothing wrong with my pull request, but feel free to let me know if you need any changes made. 

I technically do also accept sending a `faction_id` in the request, however I already do an API request of the player on the backend and no other revive services there make use of a `faction_id`. So I opted to not add any new variable to include such a thing. I don't make use of any faction name/position string so I removed that from the request. 