### PR TITLE
Wait on the gym being fully loaded before triggering an event.

### DIFF
--- a/extension/scripts/content/gym/ttGym.js
+++ b/extension/scripts/content/gym/ttGym.js
@@ -14,7 +14,10 @@
 					STATS[stat] = parseInt(json.stats[stat].value.replaceAll(",", ""));
 				}
 
-				triggerCustomListener(EVENT_CHANNELS.GYM_LOAD, { stats: STATS });
+				requireElement("[class*='skeletonWrapper___']", { invert: true })
+					.then(() => {
+						triggerCustomListener(EVENT_CHANNELS.GYM_LOAD, { stats: STATS });
+					})
 			} else if (json && step === "train") {
 				if (!json.success) return;
 
@@ -34,5 +37,6 @@
 
 		triggerCustomListener(EVENT_CHANNELS.GYM_LOAD, { stats: STATS });
 		resolve();
-	}).then(() => {});
+	}).then(() => {
+	});
 })();


### PR DESCRIPTION
Switching gyms didn't show the allowed stats. Been like this for a long while, not related to the recent changes.