### PR TITLE
Fix: Gym Graph race condition where the dark mode toggle didn't exist

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -3,7 +3,12 @@
 		"version": { "major": 7, "minor": 3, "build": 4 },
 		"title": "Beta",
 		"date": false,
-		"logs": { "features": [], "fixes": [], "changes": [], "removed": [] }
+		"logs": {
+			"features": [],
+			"fixes": [{ "message": "Fixed a race condition breaking the Gym Graph on Firefox", "contributor": "Kwack" }],
+			"changes": [],
+			"removed": []
+		}
 	},
 	{
 		"version": { "major": 7, "minor": 3, "build": 3 },

--- a/extension/scripts/features/gym-graph/ttGymGraph.js
+++ b/extension/scripts/features/gym-graph/ttGymGraph.js
@@ -132,13 +132,13 @@
 			const gymChart = createChart();
 
 			// If Torn dark mode is toggled.
-			document.find("#dark-mode-state").addEventListener("change", (event) => {
+			await requireElement("#dark-mode-state").then((el) => el.addEventListener("change", (event) => {
 				const color = event.target.checked ? "#fff" : "#000";
 				gymChart.options.scales.x.ticks.color = color;
 				gymChart.options.scales.y.ticks.color = color;
 				gymChart.options.plugins.legend.labels.color = color;
 				gymChart.update();
-			});
+			}));
 
 			showLoadingPlaceholder(wrapper, false);
 


### PR DESCRIPTION
Very difficult for me to reproduce, but it did happen very occasionally. Only seemed to occur on Firefox.

Reported by Shade [3129695], who seemed to be able to reproduce it more consistently.