### PR TITLE
Fix: hidden forum post white space

### DIFF
--- a/extension/scripts/features/forum-menu/ttForumMenu.css
+++ b/extension/scripts/features/forum-menu/ttForumMenu.css
@@ -72,14 +72,14 @@ body.dark-mode .tt-forums-button-dropdown {
 	cursor: pointer;
 	text-align: center;
 	padding: 5px !important;
-	border-bottom: 1px solid #ccc;
+	border-bottom: 1px solid transparent;
 }
 
 .thread-list > .tt-forums-hidden::after {
 	content: "";
 	display: block;
-	border-bottom: 10px solid white;
-	border-top: 1px solid #ccc;
+	border-bottom: 10px solid var(--default-panel-divider-inner-side-color);
+	border-top: 1px solid var(--default-panel-divider-outer-side-color);
 	margin: 5px -5px -5px;
 }
 


### PR DESCRIPTION
Remove whitespace from hidden forum posts  when viewed in dark mode

![image](https://github.com/user-attachments/assets/50b7106f-2fd3-44c0-abdb-7387730fe194)
