### PR TITLE
Fix personal stat average injection on Firefox

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -3,7 +3,14 @@
 		"version": { "major": 7, "minor": 3, "build": 6 },
 		"title": "Beta",
 		"date": false,
-		"logs": { "features": [], "fixes": [], "changes": [], "removed": [] }
+		"logs": {
+			"features": [],
+			"fixes": [
+				{ "message": "Fix personal stat average injection on Firefox.", "contributor": "tiksan" }
+			],
+			"changes": [],
+			"removed": []
+		}
 	},
 	{
 		"version": { "major": 7, "minor": 3, "build": 5 },

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -237,7 +237,7 @@
 		{
 			"matches": ["https://www.torn.com/personalstats.php*"],
 			"js": ["scripts/features/avg-personal-stat/avg-personal-stat.entry.js"],
-			"run_at": "document_start"
+			"run_at": "document_end"
 		},
 		{
 			"matches": ["https://www.torn.com/bazaar.php*"],


### PR DESCRIPTION
The personal stat average feature from a0f72f1e failed to inject on Firefox (but appears to be fine on Chromium) resulting in a `ReferenceError` upon `getPageStatus`.

> ReferenceError: getPageStatus is not defined avg-personal-stat.entry.js:4:6

From my understanding of TT's architecture, the injection of this feature would need to be changed from `document_start` to `document_end` as it depends on `getPageStatus` and the feature manager which would not have been added to the stack yet.

I've checked this patch on FF 132.0 and Chromium 130.0.6723.116 (for Linux).