### PR TITLE
Prevent MutationObserver error when removedNodes is empty 

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -5,7 +5,10 @@
 		"date": false,
 		"logs": {
 			"features": [],
-			"fixes": [{ "message": "Fix the company id showing something wrong.", "contributor": "DeKleineKobini" }],
+			"fixes": [
+				{ "message": "Fix the company id showing something wrong.", "contributor": "DeKleineKobini" },
+				{ "message": "Prevent error on the faction page when member list is modified", "contributor": "MOBermejo" }
+			],
 			"changes": [{ "message": "Change layout of preferences page on mobiles.", "contributor": "TheFoxMan" }],
 			"removed": []
 		}

--- a/extension/scripts/content/factions/ttFactions.js
+++ b/extension/scripts/content/factions/ttFactions.js
@@ -203,7 +203,7 @@ const isOwnFaction = getSearchParameters().get("step") === "your";
 				if (records.length > 1) return;
 
 				for (const record of records) {
-					if (!record.removedNodes?.[0].matches("#iconTray")) continue;
+					if (!record.removedNodes?.[0]?.matches("#iconTray")) continue;
 
 					const oldIconsCount = record.removedNodes?.[0].children.length;
 					const newIconsCount = record.addedNodes?.[0].children.length;

--- a/extension/scripts/global/team.js
+++ b/extension/scripts/global/team.js
@@ -217,6 +217,13 @@ const TEAM = [
 		torn: 2383326,
 		color: "white", // No explicit color chosen.
 	},
+	{
+		name: "MOBermejo",
+		title: "Developer",
+		core: false,
+		torn: 3385879,
+		color: "#DAA520",
+	},
 ];
 
 const CONTRIBUTORS = TEAM.filter(({ title, color }) => title.includes("Developer") || color).reduce(


### PR DESCRIPTION
This PR fixes a bug on the faction page that caused an error when removedNodes was empty.

The MutationObserver listens for changes to the faction member list, but if removedNodes is an empty NodeList, it triggered the following error: `Cannot read properties of undefined (reading 'matches')`

- Added optional chaining (?.) to prevent the script from calling .matches() on undefined.
- Ensures the observer safely continues when `removedNodes` exists, but is empty