### PR TITLE
$1 items in the bazaar that you can't buy are excluded from highlighting

### DIFF
--- a/extension/scripts/features/bazaar-sub-vendor-items/ttSubVendorPriceItems.entry.js
+++ b/extension/scripts/features/bazaar-sub-vendor-items/ttSubVendorPriceItems.entry.js
@@ -34,6 +34,8 @@
 
 	function highlightEverything() {
 		const items = [...document.findAll("[class*='item__'] > [class*='itemDescription__']")]
+			// filter out $1 items that you can't buy
+			.filter((element) => !element.find("[class*='isBlockedForBuying___'"))
 			.map((element) => {
 				return {
 					element,


### PR DESCRIPTION
- Just filters them out from highlighting when subvendor highlighting is on