### PR TITLE
More accurate/useful end time calculation for OC2 countdown in sidebar.

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -21,7 +21,8 @@
 				{ "message": "Migrate faction stakeouts over to API V2.", "contributor": "DeKleineKobini" },
 				{ "message": "Migrate faction last action over to API V2.", "contributor": "DeKleineKobini" },
 				{ "message": "Make icons in the popup clickable to open their corresponding pages.", "contributor": "Hashibee" },
-				{ "message": "Show some more networth types in live networth.", "contributor": "DeKleineKobini" }
+				{ "message": "Show some more networth types in live networth.", "contributor": "DeKleineKobini" },
+				{ "message": "More accurate/useful end time for OC2 countdown in sidebar", "contributor": "Phoenix" }
 			],
 			"removed": []
 		}

--- a/extension/scripts/features/oc2-time/ttOC2Time.js
+++ b/extension/scripts/features/oc2-time/ttOC2Time.js
@@ -60,9 +60,29 @@
 
 	function buildTimeLeftElement() {
 		const timeLeftElement = document.newElement({ type: "span", class: "countdown" });
+		const now = Date.now();
+		let readyAt;
+		// Torn's ready_at value corresponds to the planning finish time for currently joined members
+		// If the OC is partially filled it will not provide an accurate end time (i.e. when it will initiate)
 
-		const readyAt = userdata.organizedCrime.ready_at * 1000;
-		const timeLeft = readyAt - Date.now();
+		// Count the missing members
+		let missingMembers = 0;
+		for (const slot of userdata.organizedCrime.slots) {
+			if (slot.user_id === null) {
+				missingMembers += 1;
+			}
+		}
+
+		// Add 24 hours for every missing member
+		// The end result is that this now provides the earliest projected end/initiation time
+		if (missingMembers > 0) {
+			const missingTime = 24 * 60 * 60 * missingMembers;
+			readyAt = Math.max((userdata.organizedCrime.ready_at + missingTime) * 1000, now + missingTime * 1000);
+		} else {
+			readyAt = userdata.organizedCrime.ready_at * 1000;
+		}
+
+		const timeLeft = readyAt - now;
 
 		if (timeLeft <= TO_MILLIS.HOURS * 8) timeLeftElement.classList.add("short");
 		else if (timeLeft <= TO_MILLIS.HOURS * 12) timeLeftElement.classList.add("medium");

--- a/extension/scripts/global/team.js
+++ b/extension/scripts/global/team.js
@@ -238,6 +238,13 @@ const TEAM = [
 		torn: 2303184,
 		color: "#6ACF65",
 	},
+	{
+		name: "Phoenix",
+		title: "Developer",
+		core: false,
+		torn: 85185,
+		color: "#085185",
+	},
 ];
 
 const CONTRIBUTORS = TEAM.filter(({ title, color }) => title.includes("Developer") || color).reduce(


### PR DESCRIPTION
Torn's ready_at value corresponds to the planning finish time for currently joined members. 
If the OC is partially filled, ready_at will not provide an accurate end time (i.e. when it will initiate). 
Update the logic to account for empty slots in the OC.

My general thought process is that knowing when the OC _should_ initiate is better than looking at the sidebar and seeing your 50% full OC will initiate way earlier than the reality. A solid handful of my faction members have been caught out by this.

I had an unofficial OC2 icon script using this logic for a good while and it never lied to me. Should hold true here.