### PR TITLE
Make faction quick points work again

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -8,7 +8,9 @@
 			"fixes": [
 				{ "message": "Fix vault networth being shown twice with live networth.", "contributor": "DeKleineKobini" },
 				{ "message": "Fix attack history not updating properly.", "contributor": "DeKleineKobini" },
-				{ "message": "Update all travel features to work with the reworked travel pages.", "contributor": "DeKleineKobini" }
+				{ "message": "Faction Quick Items on mobile didn't seem to allow refills being added.", "contributor": "DeKleineKobini" },
+				{ "message": "Update all travel features to work with the reworked travel pages.", "contributor": "DeKleineKobini" },
+				{ "message": "Fix adding points to faction quick items when they are refillable", "contributor": "xentac" }
 			],
 			"changes": [
 				{ "message": "Completely disable the train button for disabled stats as extra measure.", "contributor": "DeKleineKobini" },

--- a/extension/scripts/features/faction-quick-items/ttFactionQuickItems.js
+++ b/extension/scripts/features/faction-quick-items/ttFactionQuickItems.js
@@ -449,7 +449,7 @@
 
 				item.addEventListener("click", onItemClickQuickEdit);
 			}
-			for (const refill of document.findAll("#armoury-points .give[data-role='give']")) {
+			for (const refill of document.findAll("#armoury-points .give[data-role='give'], #armoury-points .give[data-role='refill']")) {
 				refill.addEventListener("click", onItemClickQuickEdit);
 			}
 		} else {
@@ -460,7 +460,7 @@
 
 				item.removeEventListener("click", onItemClickQuickEdit);
 			}
-			for (const refill of document.findAll("#armoury-points .give[data-role='give']")) {
+			for (const refill of document.findAll("#armoury-points .give[data-role='give'], #armoury-points .give[data-role='refill']")) {
 				refill.removeEventListener("click", onItemClickQuickEdit);
 			}
 		}

--- a/extension/scripts/global/team.js
+++ b/extension/scripts/global/team.js
@@ -245,6 +245,13 @@ const TEAM = [
 		torn: 85185,
 		color: "#085185",
 	},
+	{
+		name: "xentac",
+		title: "Developer",
+		core: false,
+		torn: 3354782,
+		color: "#a569bd",
+	},
 ];
 
 const CONTRIBUTORS = TEAM.filter(({ title, color }) => title.includes("Developer") || color).reduce(


### PR DESCRIPTION
The HTML changed for how points are selected in the faction items. This fixes support for adding it to the quick items list.