### PR TITLE
Fix sidebar custom links placed above or below 'My Faction' not showing

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -20,6 +20,7 @@
 				{ "message": "Avoid errors with the faction last action feature.", "contributor": "DeKleineKobini" },
 				{ "message": "Fix faction fold infobox not always working.", "contributor": "DeKleineKobini" },
 				{ "message": "Avoid errors with the faction stats estimate filter.", "contributor": "DeKleineKobini" }
+				{ "message": "Fix sidebar custom links placed above or below 'My Faction' not showing.", "contributor": "XDeltaA77" }
 			],
 			"changes": [
 				{ "message": "Change the OC2 Highlight color on dark mode.", "contributor": "DeKleineKobini" },

--- a/extension/scripts/global/functions/torn.js
+++ b/extension/scripts/global/functions/torn.js
@@ -146,7 +146,7 @@ const ALL_AREAS = [
 	{ class: "casino", text: "Casino" },
 	{ class: "forums", text: "Forums" },
 	{ class: "hall_of_fame", text: "Hall of Fame" },
-	{ class: "my_faction", text: "My Faction" },
+	{ class: "faction", text: "My Faction" },
 	{ class: "recruit_citizens", text: "Recruit Citizens" },
 	{ class: "competitions", text: "Competitions" },
 	{ class: "community_events", text: "Community Events" },

--- a/extension/scripts/global/team.js
+++ b/extension/scripts/global/team.js
@@ -259,6 +259,13 @@ const TEAM = [
 		torn: 1853324,
 		color: "blue",
 	},
+	{
+		name: "XDeltaA77",
+		title: "Developer",
+		core: false,
+		torn: 1892226,
+		color: "#3dcc21",
+	},
 ];
 
 const CONTRIBUTORS = TEAM.filter(({ title, color }) => title.includes("Developer") || color).reduce(


### PR DESCRIPTION
Currently placement of above or below placement will not show the custom link at all as it doesn't find 'my_faction'