### PR TITLE
Adjust point cost of Mining Boom from 10 to 5

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -36,6 +36,7 @@
 				{ "message": "Trigger tablet more at 1000px instead of at 960px.", "contributor": "DeKleineKobini" },
 				{ "message": "Apply ranked war filters on an interval to follow the live updates.", "contributor": "DeKleineKobini" },
 				{ "message": "Adjust Trade Open Chat to work with Chat 3.0.", "contributor": "TheFoxMan" },
+				{ "message": "Adjust point cost of Mining Boom from 10 to 5", "contributor": "StaticFree" },
 				{ "message": "Improve compatability with the faction stats script for the ranked war filter.", "contributor": "DeKleineKobini" },
 				{ "message": "Focus on the search input by default on our settings page.", "contributor": "DeKleineKobini" }
 			],

--- a/extension/scripts/global/functions/torn.js
+++ b/extension/scripts/global/functions/torn.js
@@ -964,7 +964,7 @@ const COMPANY_INFORMATION = {
 	"Mining Corporation": {
 		1: {
 			name: "Mining Boom",
-			cost: "10",
+			cost: "5",
 			effect: "Random excavation equipment",
 		},
 		3: {

--- a/extension/scripts/global/team.js
+++ b/extension/scripts/global/team.js
@@ -266,6 +266,13 @@ const TEAM = [
 		torn: 1892226,
 		color: "#3dcc21",
 	},
+	{
+		name: "StaticFree",
+		title: "Developer",
+		core: false,
+		torn: 711045,
+		color: "steelblue",
+	},
 ];
 
 const CONTRIBUTORS = TEAM.filter(({ title, color }) => title.includes("Developer") || color).reduce(


### PR DESCRIPTION
Adjust point cost of Mining Boom from 10 to 5.

Point cost of Mining Commpany's 1* special was reduced from 10 to 5 on 29/04/2025.
https://www.torn.com/forums.php#/p=threads&t=16466566