### PR TITLE
Update ttBlackjackStrategy.js for split 2,2s into 2

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -21,7 +21,9 @@
 				{ "message": "Fix faction fold infobox not always working.", "contributor": "DeKleineKobini" },
 				{ "message": "Avoid errors with the faction stats estimate filter.", "contributor": "DeKleineKobini" },
 				{ "message": "Fix sidebar custom links placed above or below 'My Faction' not showing.", "contributor": "XDeltaA77" },
-				{ "message": "Fix 'FF Scouter' on Firefox causing visual issues on the RR page when honor were disabled.", "contributor": "DeKleineKobini" }
+				{ "message": "Fix 'FF Scouter' on Firefox causing visual issues on the RR page when honor were disabled.", "contributor": "DeKleineKobini" },
+				{ "message": "Fix Blackjack script not proposing a strategy when splitting 2s and then being dealt a 2.", "contributor": "EazzyPeazzy" }
+
 			],
 			"changes": [
 				{ "message": "Change the OC2 Highlight color on dark mode.", "contributor": "DeKleineKobini" },

--- a/extension/scripts/features/blackjack-strategy/ttBlackjackStrategy.js
+++ b/extension/scripts/features/blackjack-strategy/ttBlackjackStrategy.js
@@ -12,6 +12,19 @@
 	};
 
 	const SUGGESTIONS = {
+		// 4 is only used in a very specific case : After 2,2 is split and you get dealt another 2. Re-splits are not allowed, and therefore you need a backup strategy (which is to always hit, based on the strategy for 2,2).
+		4: {
+			2: "H",
+			3: "H",
+			4: "H",
+			5: "H",
+			6: "H",
+			7: "H",
+			8: "H",
+			9: "H",
+			10: "H",
+			A: "H",
+		},
 		5: {
 			2: "H",
 			3: "H",

--- a/extension/scripts/global/team.js
+++ b/extension/scripts/global/team.js
@@ -273,6 +273,13 @@ const TEAM = [
 		torn: 711045,
 		color: "steelblue",
 	},
+	{
+		name: "EazzyPeazzy",
+		title: "Developer",
+		core: false,
+		torn: 2708376,
+		color: "#65000b",
+	},
 ];
 
 const CONTRIBUTORS = TEAM.filter(({ title, color }) => title.includes("Developer") || color).reduce(


### PR DESCRIPTION
I ran into a small bug on a very specific case : when you're dealt 2,2, you split them, and you're then dealt another 2. Since you can't split again and the array didn't have an entry for when you're dealt 4 (because the only way to be dealt 4 is 2,2 and then you split), the script didn't show what to play then. I added this small case.

I'm EazzyPeazzy [2708376] in game :)