### PR TITLE
Add Blackjack fixes

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -22,7 +22,9 @@
 				{ "message": "Avoid errors with the faction stats estimate filter.", "contributor": "DeKleineKobini" },
 				{ "message": "Fix sidebar custom links placed above or below 'My Faction' not showing.", "contributor": "XDeltaA77" },
 				{ "message": "Fix 'FF Scouter' on Firefox causing visual issues on the RR page when honor were disabled.", "contributor": "DeKleineKobini" },
-				{ "message": "Fix Blackjack script not proposing a strategy when splitting 2s and then being dealt a 2.", "contributor": "EazzyPeazzy" }
+				{ "message": "Update source for blackjack strategy to reflect hitting is authorized after split Aces.", "contributor": "EazzyPeazzy"},
+				{ "message": "Fix Blackjack script not proposing a strategy when splitting 2s and then being dealt another 2.", "contributor": "EazzyPeazzy"},
+				{ "message": "Fix Blackjack script not proposing the right play when splitting Aces and being dealt another Ace.", "contributor": "EazzyPeazzy"}
 			],
 			"changes": [
 				{ "message": "Change the OC2 Highlight color on dark mode.", "contributor": "DeKleineKobini" },

--- a/extension/pages/settings/settings.html
+++ b/extension/pages/settings/settings.html
@@ -1502,7 +1502,7 @@
 							<div class="tabbed note">
 								Based on
 								<a
-									href="http://www.beatingbonuses.com/bjstrategy.php?decks=8&soft17=stand&doubleon=any2cards&peek=off&das=on&charlie=on&surrender=earlyf&opt=1&btn=Generate+Strategy"
+									href="https://www.beatingbonuses.com/bjstrategy.php?decks=8&soft17=stand&doubleon=any2cards&peek=off&das=on&dsa=on&charlie=on&surrender=earlyf&opt=1&btn=Generate+Strategy"
 								>
 									this strategy calculator.
 								</a>

--- a/extension/scripts/features/blackjack-strategy/ttBlackjackStrategy.js
+++ b/extension/scripts/features/blackjack-strategy/ttBlackjackStrategy.js
@@ -11,6 +11,11 @@
 		R: "Surrender",
 	};
 
+	/* these suggestions come from :
+	https://www.beatingbonuses.com/bjstrategy.php?decks=8&soft17=stand&doubleon=any2cards&peek=off&das=on&dsa=on&charlie=on&surrender=earlyf&opt=1&btn=Generate+Strategy
+	(8 decks, double on any 2 cards, Double after Split, Hit Split Aces, 6-Card charlie, No Resplits Allowed, Dealer Stands on Soft 17, Dealer does not peek, full early surrender)
+	*/
+
 	const SUGGESTIONS = {
 		// 4 is only used in a very specific case : After 2,2 is split and you get dealt another 2. Re-splits are not allowed, and therefore you need a backup strategy (which is to always hit, based on the strategy for 2,2).
 		4: {
@@ -455,7 +460,7 @@
 			8: "P",
 			9: "P",
 			10: "P",
-			A: "H",
+			A: "P",
 		},
 	};
 

--- a/extension/scripts/features/blackjack-strategy/ttBlackjackStrategy.js
+++ b/extension/scripts/features/blackjack-strategy/ttBlackjackStrategy.js
@@ -590,7 +590,7 @@
 						if (hand[0] === hand[1]) {
 							let value;
 							if (isNaN(hand[0])) {
-								if (hand[0] === "A") value = 12;
+								if (hand[0] === "A") value = 2;
 								else value = 20;
 							} else value = parseInt(hand[0]) * 2;
 


### PR DESCRIPTION
I updated the strategy page used for the Blackjack strategy, since it didn't use the right parameters : Torn actually allows hitting after splitting Aces (which increases our edge against the house, from 0.2% to 0.38% !).
I also corrected the suggestion for split Aces into Ace, which was parsed as a 12 and thus a Stand in some cases, whereas you should always Hit in that case (since you can't bust). Parsing it as a 2 fixes the problem (2 is now an option thanks to the PR I submitted on thursday, thanks for the merge).

I am not sure if I should split my commits differently, and/or if I should put the updated strategy in the "changes" part of the changelog instead of the fixes part. Let me know !
