### PR TITLE
Fix missing FF score exception in faction pages

### DIFF
--- a/extension/scripts/features/ff-scouter/ttFFScouterFaction.js
+++ b/extension/scripts/features/ff-scouter/ttFFScouterFaction.js
@@ -95,7 +95,7 @@
 				document.newElement({
 					type: "li",
 					class: ["table-cell", "lvl", "tt-ff-scouter-faction-list-value"],
-					text: ff.toFixed(2),
+					text: ff !== null ? ff.toFixed(2) : "?",
 					style: {
 						backgroundColor: backgroundColor,
 						color: textColor,


### PR DESCRIPTION
The FF feature fails in faction pages when a single player is missing a FF score. This will just make it display `?` instead of failing on `ff.toFixed(2)`.