### PR TITLE
Improved trade UI by displaying market value breakdown per item

### DIFF
--- a/extension/scripts/features/trade-values/ttTradeValues.css
+++ b/extension/scripts/features/trade-values/ttTradeValues.css
@@ -15,6 +15,15 @@
 	color: var(--tt-color-item-text);
 }
 
+.tt-item-value-unit {
+	color: var(--tt-color-item-text);
+}
+
+.tt-item-value-quantity,
+.tt-item-value-total {
+	color: var(--tt-color-item-quantity);
+}
+
 body.tt-trade-values .log .desc {
 	position: relative;
 	color: var(--default-color) !important;

--- a/extension/scripts/features/trade-values/ttTradeValues.css
+++ b/extension/scripts/features/trade-values/ttTradeValues.css
@@ -15,12 +15,13 @@
 	color: var(--tt-color-item-text);
 }
 
-.tt-item-value-unit {
+.tt-item-value-unit,
+.tt-item-value-total {
 	color: var(--tt-color-item-text);
 }
 
-.tt-item-value-quantity,
-.tt-item-value-total {
+.tt-item-value-quantity {
+	font-weight: bold;
 	color: var(--tt-color-item-quantity);
 }
 

--- a/extension/scripts/features/trade-values/ttTradeValues.js
+++ b/extension/scripts/features/trade-values/ttTradeValues.js
@@ -101,7 +101,29 @@
 				const worth = parseInt(marketValue * quantity);
 				totalValue += worth;
 
-				item.appendChild(document.newElement({ type: "span", class: "tt-item-value", text: formatNumber(worth, { currency: true }) }));
+				//item.appendChild(document.newElement({ type: "span", class: "tt-item-value", text: formatNumber(worth, { currency: true }) }));
+				item.appendChild(document.newElement({
+					type: "span",
+					class: "tt-item-value",
+					children: [
+						document.newElement({
+							type: "span",
+							class: "tt-item-value-unit",
+							text: formatNumber(marketValue, { currency: true }),
+						}),
+						document.createTextNode(" | "),
+						document.newElement({
+							type: "span",
+							class: "tt-item-value-quantity",
+							text: `${quantity}x = `,
+						}),
+						document.newElement({
+							type: "span",
+							class: "tt-item-value-total",
+							text: formatNumber(worth, { currency: true }),
+						}),
+					]
+				}));
 			}
 
 			if (totalValue !== 0) {


### PR DESCRIPTION
The current trade interface only displays the total value of items, which makes it difficult to verify the individual unit price, especially when comparing them against receipts issued by traders on Torn Exchange.

This update enhances the trade window by appending a market value breakdown next to each item, similar to how item market values are shown in the torn inventory. 

For example, an item now for example displays:
$12,000 | 4x = $48,000

I’ve also tested with inflated item values (e.g., Small First Aid Kit) to ensure the formatting works with large numbers and longer text.

Do note that I do not have a complete understanding of what TornTools has to consider such as individual user settings or other considerations like mobile or pc layouts if that is applicable, so my code might need further review.

Additionally, I might have left some remnants of the previous code commented out or left unused in the .css file. 
It should be removed if considered unnecessary.

Images showcasing this new cosmetic feature:

**Before:**

![chrome_lDDMtnBgb7](https://github.com/user-attachments/assets/27393eb2-f037-4a48-b114-0301820297ab)

**After:**

![Photos_ID2NwkBvDG](https://github.com/user-attachments/assets/0d6754b8-6cec-457d-a6e4-0d83b50cd2a3)
