### PR TITLE
Align backdrops when using `ttAlignLeft`.

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -11,7 +11,10 @@
 				{ "message": "Fix scrolling through the sidebar not being possible on the items page on mobile.", "contributor": "DeKleineKobini" },
 				{ "message": "Avoid errors with the 'Highlight Cheap Items' when there is no price element.", "contributor": "DeKleineKobini" }
 			],
-			"changes": [{ "message": "Link to the explosive grenades wiki page for the 'Loud and Clear' mission hint.", "contributor": "DeKleineKobini" }],
+			"changes": [
+				{ "message": "Link to the explosive grenades wiki page for the 'Loud and Clear' mission hint.", "contributor": "DeKleineKobini" },
+				{ "message": "Align the page backdrops when using the align left feature.", "contributor": "—" }
+			],
 			"removed": [
 				{
 					"message": "Remove 'Defender Last Action' due to the information no longer being available without many API calls.",

--- a/extension/scripts/features/align-left/ttAlignLeft.css
+++ b/extension/scripts/features/align-left/ttAlignLeft.css
@@ -10,3 +10,7 @@
 .tt-align-left .without-sidebar #mainContainer .content-wrapper {
 	margin-left: 20px;
 }
+
+.tt-align-left .d .backdrops-container .custom-bg-desktop {
+	background-position: calc(967px + 20px) top;
+}


### PR DESCRIPTION
Simple CSS-only change to also align backdrops when the "align to the left" feature is enabled.

Doesn't affect mobile views (where backdrops already span the whole page's width), and takes into account both the fixed container size (`976px`) and margin (`20px`).

Should this be accepted as-is, feel free to reassign changelog credit to someone.