### PR TITLE
Loose jsdoc and tsconfig type check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ extension/scripts/eslint.json
 
 extension/find.txt
 extension/find.txtf
+
+node_modules

--- a/extension/global.d.ts
+++ b/extension/global.d.ts
@@ -1,0 +1,39 @@
+interface NewElementOptions {
+	type: keyof HTMLElementTagNameMap;
+	id?: string;
+	class?: string;
+	text?: string;
+	html?: string;
+	value?: any | (() => any);
+	href?: string;
+	children?: HTMLElement[];
+	attributes?: Record<string, string> | (() => Record<string, string>);
+	events?: Partial<{ [E in keyof GlobalEventHandlersEventMap]: (e: GlobalEventHandlersEventMap[E]) => void }>;
+	style?: { [P in keyof CSSStyleDeclaration as P extends string ? (CSSStyleDeclaration[P] extends string ? P : never) : never]?: CSSStyleDeclaration[P] };
+	dataset?: {
+		[name: string]: string;
+	};
+}
+
+interface FindOptions {
+	text: string;
+}
+
+interface Document {
+	newElement<K extends keyof HTMLElementTagNameMap>(tagName: K): HTMLElementTagNameMap[K];
+	newElement(options: NewElementOptions): HTMLElement;
+	find(selector: string, options?: Partial<FindOptions>): HTMLElement;
+	findAll(selector: string): NodeListOf<HTMLElement>;
+	setClass(...classNames: string[]): void;
+}
+
+interface Element {
+	find(selector: string, options?: Partial<FindOptions>): HTMLElement;
+	findAll(selector: string): NodeListOf<HTMLElement>;
+	setClass(...classNames: string[]): void;
+}
+
+interface DOMTokenList {
+	contains(className: string): boolean;
+	removeSpecial(className: string): void;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "torntools_extension",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "chrome-types": "^0.1.377"
+      }
+    },
+    "node_modules/chrome-types": {
+      "version": "0.1.377",
+      "resolved": "https://registry.npmjs.org/chrome-types/-/chrome-types-0.1.377.tgz",
+      "integrity": "sha512-cOS9iXRCtBewHJVBGpe88qA2Xly3p4V5hgxerChVhUVnJIAr6QcIIdP1Ryac5iautq+IeMdu3ZKh2y0rZQR4qw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "chrome-types": "^0.1.377"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "none",
+    "outDir": "dist",
+    "target": "esnext",
+    "allowJs": true,
+    "types": ["chrome-types"]
+  },
+  "include": ["extension/**/*"]
+}


### PR DESCRIPTION
Pros:
1. Full type safety and navigation in js files with no errors - best effort mode
2. No build step - regular js
3. Global types work - like chrome and document etc...

Cons:
1. Requires npm install
2. No easy way to add types (either jsdoc which is meh or .d.ts files)
3. No way to actually enforce type problems incrementally... either ignore all or check all so errors can still happen

How it works?
1. tsconfig gives type safety and navigation
2. package.json allows for chrome types
3. jsdoc or .d.ts files for types