### PR TITLE
Add crime status filter to OC2 filter feature

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -1,17 +1,25 @@
 [
+
 	{
 		"version": { "major": 7, "minor": 8, "build": 5 },
 		"title": "Beta",
 		"date": false,
 		"logs": {
-			"features": [],
-			"fixes": [],
+			"features": [{ "message": "Notification for being offline a certain amount of hours.", "contributor": "DeKleineKobini" },
+				{ "message": "Add crime status filter to OC2 filter (Paid/Unpaid/Chain/Failed) - appears on completed crimes tab.", "contributor": "vALT0r" }],
+			"fixes": [
+				{ "message": "Hide burglary filter when no longer on the burglary page.", "contributor": "DeKleineKobini" },
+				{ "message": "Resolve chat highlight issue when there is no api key present.", "contributor": "DeKleineKobini" },
+				{ "message": "Fix casino net total not being shown on all games anymore.", "contributor": "DeKleineKobini" },
+				{ "message": "Don't break the travel table if an item no longer exists.", "contributor": "DeKleineKobini" }
+			],
 			"changes": [
 				{ "message": "Optimize item market API call by limiting it to the amount of items we show.", "contributor": "DeKleineKobini" },
 				{
 					"message": "Move all API calls to the V2 API, using the legacy selections parameter instead to reduce the amount of calls we do again.",
 					"contributor": "DeKleineKobini"
-				}
+				},
+				{ "message": "Minor improvement in the error handling of TornStats calls.", "contributor": "DeKleineKobini" }
 			],
 			"removed": []
 		}

--- a/extension/pages/settings/settings.html
+++ b/extension/pages/settings/settings.html
@@ -1107,10 +1107,6 @@
 							<label for="faction-oc2Filter">Enable OC2 filters.</label>
 						</div>
 						<div class="option">
-							<input id="faction-oc2StatusFilter" type="checkbox" />
-							<label for="faction-oc2StatusFilter">Enable OC2 crime status filter (Paid/Unpaid/Failed).</label>
-						</div>
-						<div class="option">
 							<input id="faction-warnCrime" type="checkbox" />
 							<label for="faction-warnCrime">Warn when joining a crime without passing the conditions.</label>
 						</div>

--- a/extension/pages/settings/settings.html
+++ b/extension/pages/settings/settings.html
@@ -1107,6 +1107,10 @@
 							<label for="faction-oc2Filter">Enable OC2 filters.</label>
 						</div>
 						<div class="option">
+							<input id="faction-oc2StatusFilter" type="checkbox" />
+							<label for="faction-oc2StatusFilter">Enable OC2 crime status filter (Paid/Unpaid/Failed).</label>
+						</div>
+						<div class="option">
 							<input id="faction-warnCrime" type="checkbox" />
 							<label for="faction-warnCrime">Warn when joining a crime without passing the conditions.</label>
 						</div>

--- a/extension/scripts/content/factions/ttFactions.js
+++ b/extension/scripts/content/factions/ttFactions.js
@@ -71,7 +71,7 @@ const isOwnFaction = getSearchParameters().get("step") === "your";
 				})
 				.catch((cause) => loaded || console.error(cause));
 			requireElement("#faction-crimes-root [class*='buttonsContainer___']", { maxCycles: 20 })
-				.then(async () => {
+				.then(async (buttonsContainer) => {
 					loaded = true;
 
 					const list = await requireElement("#faction-crimes-root .page-head-delimiter + div:not([class])");
@@ -81,6 +81,16 @@ const isOwnFaction = getSearchParameters().get("step") === "your";
 					triggerCustomListener(EVENT_CHANNELS.FACTION_CRIMES2);
 
 					new MutationObserver(() => triggerCustomListener(EVENT_CHANNELS.FACTION_CRIMES2_REFRESH)).observe(list, { childList: true });
+
+					buttonsContainer.querySelectorAll("button").forEach((button) => {
+						const tabName = button.querySelector("[class*='tabName___']").textContent.trim();
+
+						new MutationObserver(() => {
+							if (!button.className.includes("active___")) return;
+
+							triggerCustomListener(EVENT_CHANNELS.FACTION_CRIMES2_TAB, { tabName });
+						}).observe(button, { attributes: true, attributeFilter: ["class"] });
+					});
 				})
 				.catch((cause) => loaded || console.error(cause));
 		}

--- a/extension/scripts/features/oc2-filter/ttOC2Filter.js
+++ b/extension/scripts/features/oc2-filter/ttOC2Filter.js
@@ -11,7 +11,7 @@
 		addFilter,
 		removeFilter,
 		{
-			storage: ["settings.pages.faction.oc2Filter"],
+			storage: ["settings.pages.faction.oc2Filter", "settings.pages.faction.oc2StatusFilter"],
 		},
 		() => {
 			if (hasOC1Data()) return "Still on OC1.";
@@ -70,18 +70,42 @@
 		filterContent.appendChild(difficultyFilter.element);
 		localFilters.difficulty = { getSelections: difficultyFilter.getSelections };
 
+		// Crime Status Filter (always create if enabled, show/hide based on tab)
+		if (settings.pages.faction.oc2StatusFilter) {
+			const statusFilter = createFilterSection({
+				title: "Crime Status",
+				checkboxes: [
+					{ id: "paid", description: "Paid" },
+					{ id: "unpaid", description: "Unpaid" },
+					{ id: "chain", description: "Chain" },
+					{ id: "failed", description: "Failed" },
+				],
+				defaults: filters.oc2.status || ["paid", "unpaid", "chain", "failed"],
+				callback: applyFilters,
+			});
+			filterContent.appendChild(statusFilter.element);
+			localFilters.status = { getSelections: statusFilter.getSelections };
+			
+			// Initially hide/show based on current tab
+			updateStatusFilterVisibility();
+		}
+
 		await applyFilters();
 	}
 
 	async function applyFilters() {
 		await requireElement(".page-head-delimiter + div:not([class*='manualSpawnerContainer___'])");
 
+		// Update status filter visibility based on current tab
+		updateStatusFilterVisibility();
+
 		// Get the set filters
 		const content = findContainer("OC Filter", { selector: "main" });
 
 		const difficulty = localFilters.difficulty.getSelections(content).map((l) => parseInt(l));
+		const status = localFilters.status ? localFilters.status.getSelections(content) : [];
 
-		const filters = { difficulty };
+		const filters = { difficulty, status };
 
 		// Save the filters
 		await ttStorage.change({ filters: { oc2: filters } });
@@ -102,6 +126,15 @@
 			return;
 		}
 
+		// Check crime status filter (only apply if enabled, we're on completed crimes tab, and filters are set)
+		if (settings.pages.faction.oc2StatusFilter && filters.status.length && isCompletedCrimesTab()) {
+			const crimeStatus = getCrimeStatus(row);
+			if (crimeStatus && !filters.status.includes(crimeStatus)) {
+				hide("status");
+				return;
+			}
+		}
+
 		show();
 
 		function show() {
@@ -118,5 +151,64 @@
 	function removeFilter() {
 		removeContainer("OC Filter");
 		document.findAll(".tt-oc2-list .tt-hidden").forEach((x) => x.classList.remove("tt-hidden"));
+	}
+
+	// Helper function to determine if we're on the completed crimes tab
+	function isCompletedCrimesTab() {
+		// Check if we're viewing completed crimes vs recruiting or planning
+		const activeTab = document.querySelector("#faction-crimes-root [class*='buttonsContainer___'] > [class*='active___']");
+		
+		if (!activeTab) {
+			return false; // Default to false if we can't determine tab
+		}
+		
+		const tabText = activeTab.textContent.trim().toLowerCase();
+		
+		// Check if the active tab is NOT recruiting or planning (so it must be completed)
+		return !tabText.includes('recruiting') && !tabText.includes('planning');
+	}
+
+	function updateStatusFilterVisibility() {
+		// The createFilterSection creates a class based on the title: "Crime Status" becomes "crimeStatus__section-class"
+		const statusFilterSection = document.querySelector('.crimeStatus__section-class');
+		if (statusFilterSection) {
+			const isCompleted = isCompletedCrimesTab();
+			statusFilterSection.style.display = isCompleted ? 'block' : 'none';
+		}
+	}
+
+	// Helper function to determine crime status from the row element
+	function getCrimeStatus(row) {
+		// Check for failed crimes - look for div with class containing "failed"
+		const failedDiv = row.querySelector('div[class*="failed"]');
+		if (failedDiv) {
+			return 'failed';
+		}
+		
+		// Check for success crimes - look for div with class containing "success"
+		const successDiv = row.querySelector('div[class*="success"]');
+		if (successDiv) {
+			// For successful crimes, check if it's paid, unpaid, or chain
+			
+			// Check for paid crimes - look for span with aria-label="Paid"
+			const paidSpan = row.querySelector('span[aria-label="Paid"]');
+			if (paidSpan) {
+				return 'paid';
+			}
+			
+			// Check for unpaid crimes - look for button with class containing "payoutBtn" and text "PayOut"
+			const payoutButton = row.querySelector('button[class*="payoutBtn"]');
+			if (payoutButton && payoutButton.textContent.includes('PayOut')) {
+				return 'unpaid';
+			}
+			
+			// Check for chain crimes - look for div with class containing "nextCrimeContainer"
+			const nextCrimeDiv = row.querySelector('div[class*="nextCrimeContainer"]');
+			if (nextCrimeDiv) {
+				return 'chain';
+			}
+		}
+		
+		return null;
 	}
 })();

--- a/extension/scripts/features/oc2-filter/ttOC2Filter.js
+++ b/extension/scripts/features/oc2-filter/ttOC2Filter.js
@@ -24,6 +24,11 @@
 
 			addFilter();
 		});
+		CUSTOM_LISTENERS[EVENT_CHANNELS.FACTION_CRIMES2_TAB].push(() => {
+			if (!feature.enabled()) return;
+
+			addFilter();
+		});
 		CUSTOM_LISTENERS[EVENT_CHANNELS.FACTION_CRIMES2_REFRESH].push(() => {
 			if (!feature.enabled()) return;
 

--- a/extension/scripts/features/oc2-filter/ttOC2Filter.js
+++ b/extension/scripts/features/oc2-filter/ttOC2Filter.js
@@ -151,15 +151,15 @@
 	function isCompletedCrimesTab() {
 		// Check if we're viewing completed crimes
 		const activeTab = document.querySelector("#faction-crimes-root [class*='buttonsContainer___'] > [class*='active___']");
-		
+
 		if (!activeTab) {
 			return false; // Default to false if we can't determine tab
 		}
-		
+
 		const tabText = activeTab.textContent.trim().toLowerCase();
-		
+
 		// Check if the active tab is "completed"
-		return tabText.includes('completed');
+		return tabText.includes("completed");
 	}
 
 	// Helper function to determine crime status from the row element
@@ -167,33 +167,35 @@
 		// Check for failed crimes - look for div with class containing "failed"
 		const failedDiv = row.querySelector('div[class*="failed"]');
 		if (failedDiv) {
-			return 'failed';
+			return "failed";
 		}
-		
+
 		// Check for success crimes - look for div with class containing "success"
 		const successDiv = row.querySelector('div[class*="success"]');
 		if (successDiv) {
 			// For successful crimes, check if it's paid, unpaid, or chain
-			
+
 			// Check for paid crimes - look for span with aria-label="Paid"
 			const paidSpan = row.querySelector('span[aria-label="Paid"]');
 			if (paidSpan) {
-				return 'paid';
+				return "paid";
 			}
-			
+
 			// Check for unpaid crimes - look for button with class containing "payoutBtn" and text "PayOut"
 			const payoutButton = row.querySelector('button[class*="payoutBtn"]');
-			if (payoutButton && payoutButton.textContent.includes('PayOut')) {
-				return 'unpaid';
+			if (payoutButton && payoutButton.textContent.includes("PayOut")) {
+				return "unpaid";
 			}
-			
+
 			// Check for chain crimes - look for div with class containing "nextCrimeContainer"
 			const nextCrimeDiv = row.querySelector('div[class*="nextCrimeContainer"]');
 			if (nextCrimeDiv) {
-				return 'chain';
+				return "chain";
 			}
+
+			return "unpaid";
 		}
-		
+
 		return null;
 	}
 })();

--- a/extension/scripts/global/functions/listeners.js
+++ b/extension/scripts/global/functions/listeners.js
@@ -18,6 +18,7 @@ const EVENT_CHANNELS = {
 	FACTION_ARMORY_TAB: "faction-armory-tab",
 	FACTION_CRIMES: "faction-crimes",
 	FACTION_CRIMES2: "faction-crimes2",
+	FACTION_CRIMES2_TAB: "faction-crimes2-tab",
 	FACTION_CRIMES2_REFRESH: "faction-crimes2-refresh",
 	FACTION_GIVE_TO_USER: "faction-give-to-user",
 	FACTION_UPGRADE_INFO: "faction-upgrade-info",

--- a/extension/scripts/global/globalData.js
+++ b/extension/scripts/global/globalData.js
@@ -628,6 +628,7 @@ const DEFAULT_STORAGE = {
 				stakeout: new DefaultSetting({ type: "boolean", defaultValue: true }),
 				showFactionSpy: new DefaultSetting({ type: "boolean", defaultValue: true }),
 				oc2Filter: new DefaultSetting({ type: "boolean", defaultValue: true }),
+				oc2StatusFilter: new DefaultSetting({ type: "boolean", defaultValue: true }),
 				warnCrime: new DefaultSetting({ type: "boolean", defaultValue: false }),
 			},
 			property: {
@@ -948,6 +949,7 @@ const DEFAULT_STORAGE = {
 		},
 		oc2: {
 			difficulty: new DefaultSetting({ type: "array", defaultValue: [] }),
+			status: new DefaultSetting({ type: "array", defaultValue: [] }),
 		},
 	},
 	userdata: new DefaultSetting({ type: "object", defaultValue: {} }),

--- a/extension/scripts/global/globalData.js
+++ b/extension/scripts/global/globalData.js
@@ -628,7 +628,6 @@ const DEFAULT_STORAGE = {
 				stakeout: new DefaultSetting({ type: "boolean", defaultValue: true }),
 				showFactionSpy: new DefaultSetting({ type: "boolean", defaultValue: true }),
 				oc2Filter: new DefaultSetting({ type: "boolean", defaultValue: true }),
-				oc2StatusFilter: new DefaultSetting({ type: "boolean", defaultValue: true }),
 				warnCrime: new DefaultSetting({ type: "boolean", defaultValue: false }),
 			},
 			property: {

--- a/extension/scripts/global/team.js
+++ b/extension/scripts/global/team.js
@@ -280,6 +280,13 @@ const TEAM = [
 		torn: 2708376,
 		color: "#65000b",
 	},
+	{
+		name: "vALT0r",
+		title: "Developer",
+		core: false,
+		torn: 767373,
+		color: "#ff6b35",
+	},
 ];
 
 const CONTRIBUTORS = TEAM.filter(({ title, color }) => title.includes("Developer") || color).reduce(


### PR DESCRIPTION
- Add status filter (Paid/Unpaid/Chain/Failed) that only appears on completed crimes tab
- Implement dynamic tab detection and filter visibility
- Add crime status detection logic based on DOM structure
- Include settings integration for filter persistence