### PR TITLE
Set workflows to cancel in progress ones.

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -1,4 +1,5 @@
 name: Pack new version
+
 on:
   workflow_dispatch:
     inputs:
@@ -26,6 +27,10 @@ on:
         type: boolean
         description: Commit beta versions
         default: true
+
+concurrency:
+  group: ${{ github.repository }}
+  cancel-in-progress: true
 
 jobs:
   publish:
@@ -231,3 +236,4 @@ jobs:
         if: ${{ inputs.commit_beta_changes }}
         with:
           message: "Pack v${{ env.version }} and update to v${{ env.newVersion }}"
+

--- a/.github/workflows/run-prettier.yml
+++ b/.github/workflows/run-prettier.yml
@@ -1,10 +1,16 @@
 name: Run Prettier
+
 on:
     push:
         branches: [master]
         paths:
           - 'extension/**'
     workflow_dispatch:
+
+concurrency:
+    group: ${{ github.repository }}
+    cancel-in-progress: true
+
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -29,3 +35,4 @@ jobs:
               with:
                   message: Apply prettier changes.
                   default_author: github_actions
+


### PR DESCRIPTION
Current configuration allows workflows to run even without any concurrency limits. This PR changes them to cancel any in progress workflows and execute the latest ones.