### PR TITLE
Fix CD End Times on mobile "click".

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -13,7 +13,8 @@
 				{ "message": "Specialist gyms refactor.", "contributor": "AllMight" },
 				{ "message": "Update can energy formula to take the event into account.", "contributor": "DeKleineKobini" },
 				{ "message": "Update alcohol nerve formula to take the events into account.", "contributor": "DeKleineKobini" },
-				{ "message": "Update candy happy formula to take the event into account.", "contributor": "DeKleineKobini" }
+				{ "message": "Update candy happy formula to take the event into account.", "contributor": "DeKleineKobini" },
+				{ "message": "Change cooldown end times to work on \"click\" on mobile.", "contributor": "TheFoxMan" }
 			],
 			"removed": []
 		}

--- a/extension/scripts/features/cooldown-end-times/ttCooldownEndTimes.js
+++ b/extension/scripts/features/cooldown-end-times/ttCooldownEndTimes.js
@@ -16,7 +16,9 @@
 
 	async function addEndTimes() {
 		const statusIcons = await requireElement("#sidebarroot [class*='status-icons__']");
-		statusIcons.addEventListener("mouseover", listener);
+		let isTouchDevice = await checkDevice();
+		isTouchDevice = isTouchDevice.mobile || isTouchDevice.tablet;
+		statusIcons.addEventListener(!isTouchDevice ? "mouseover" : "click", listener);
 
 		async function listener(event) {
 			if (!event.target.closest("li")?.matches("[class*='icon']")) return;


### PR DESCRIPTION
CD end time was not displaying on mobile, as the event is `mouseover` and mobiles have `click`.