### PR TITLE
Exclude torn tools from running on the Swagger page

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -116,8 +116,7 @@
 			"matches": ["https://www.torn.com/*.php*"],
 			"exclude_matches": [
 				"https://www.torn.com/logout.php*",
-				"https://www.torn.com/swagger.php*",
-				"https://www.torn.com/joblisting.php*"
+				"https://www.torn.com/swagger.php*"
 			],
 			"css": [
 				"scripts/features/colored-chat/ttColoredChat.css",
@@ -154,8 +153,7 @@
 			"exclude_matches": [
 				"https://www.torn.com/logout.php*",
 				"https://www.torn.com/loader.php?sid=attack&*",
-				"https://www.torn.com/swagger.php*",
-				"https://www.torn.com/joblisting.php*"
+				"https://www.torn.com/swagger.php*"
 			],
 			"css": [
 				"scripts/features/hide-leave/ttHideLeave.css",
@@ -185,8 +183,7 @@
 			"exclude_matches": [
 				"https://www.torn.com/logout.php*",
 				"https://www.torn.com/loader.php?sid=attack&*",
-				"https://www.torn.com/swagger.php*",
-				"https://www.torn.com/joblisting.php*"
+				"https://www.torn.com/swagger.php*"
 			],
 			"css": [
 				"scripts/features/custom-links/ttCustomLinks.css",


### PR DESCRIPTION
- [x] Read `CONTRIBUTING.md`.
- [ ] Added your name in `extension/scripts/global/team.ts` file.

Is this PR:
- [ ] for a new feature ?
- [x] an issue fix ?
- [ ] a developer QoL PR ?

**Purpose of PR:**
The swagger page was loading slow as a snail.
After profiling i found that it was the featureManagerInterval running like crazy. And it's not even supposed to be running on the Swagger page.
So I added a few exclusions.

**Linked issues:**
None
