### PR TITLE
Replace the pattern to compare featuremanagers type with undefined

### DIFF
--- a/extension/scripts/features/achievements/ttAchievements.entry.ts
+++ b/extension/scripts/features/achievements/ttAchievements.entry.ts
@@ -1,12 +1,8 @@
 (async () => {
-	await new Promise<void>((resolve) => {
-		const featureManagerIntervalID = setInterval(() => {
-			while (typeof featureManager === "undefined") {}
-
-			clearInterval(featureManagerIntervalID);
-			resolve();
-		}, 100);
-	});
+	if ((await featureManagerLoaded()) !== true) {
+		// @ts-ignore
+		return;
+	}
 
 	await requireElement("body");
 	const devices = await checkDevice();

--- a/extension/scripts/features/disable-ally-attacks/ttDisableAllyAttacksLoader.entry.ts
+++ b/extension/scripts/features/disable-ally-attacks/ttDisableAllyAttacksLoader.entry.ts
@@ -1,12 +1,7 @@
 (async () => {
-	await new Promise<void>((resolve) => {
-		const featureManagerIntervalID = setInterval(() => {
-			while (typeof featureManager === "undefined") {}
-
-			clearInterval(featureManagerIntervalID);
-			resolve();
-		}, 100);
-	});
+	if ((await featureManagerLoaded()) !== true) {
+		return;
+	}
 
 	const feature = featureManager.registerFeature(
 		"Disable Ally Attacks",

--- a/extension/scripts/features/hide-icons/ttHideIcons.entry.ts
+++ b/extension/scripts/features/hide-icons/ttHideIcons.entry.ts
@@ -1,12 +1,7 @@
 (async () => {
-	await new Promise<void>((resolve) => {
-		const featureManagerIntervalID = setInterval(() => {
-			while (typeof featureManager === "undefined") {}
-
-			clearInterval(featureManagerIntervalID);
-			resolve();
-		}, 100);
-	});
+	if(await featureManagerLoaded() !== true){
+		return;
+	}
 
 	featureManager.registerFeature(
 		"Hide Icons",

--- a/extension/scripts/features/hide-leave/ttHideLeave.entry.ts
+++ b/extension/scripts/features/hide-leave/ttHideLeave.entry.ts
@@ -1,12 +1,7 @@
 (async () => {
-	await new Promise<void>((resolve) => {
-		const featureManagerIntervalID = setInterval(() => {
-			while (typeof featureManager === "undefined") {}
-
-			clearInterval(featureManagerIntervalID);
-			resolve();
-		}, 100);
-	});
+	if ((await featureManagerLoaded()) !== true) {
+		return;
+	};
 
 	featureManager.registerFeature(
 		"Hide Leave Buttons",

--- a/extension/scripts/features/hide-tutorials/ttHideTutorials.entry.ts
+++ b/extension/scripts/features/hide-tutorials/ttHideTutorials.entry.ts
@@ -1,12 +1,7 @@
 (async () => {
-	await new Promise<void>((resolve) => {
-		const featureManagerIntervalID = setInterval(() => {
-			while (typeof featureManager === "undefined") {}
-
-			clearInterval(featureManagerIntervalID);
-			resolve();
-		}, 100);
-	});
+	if ((await featureManagerLoaded()) !== true) {
+		return;
+	}
 
 	featureManager.registerFeature(
 		"Hide Tutorials",

--- a/extension/scripts/features/highlight-energy-refill/ttHighlightEnergyRefill.entry.ts
+++ b/extension/scripts/features/highlight-energy-refill/ttHighlightEnergyRefill.entry.ts
@@ -1,12 +1,7 @@
 (async () => {
-	await new Promise<void>((resolve) => {
-		const featureManagerIntervalID = setInterval(() => {
-			while (typeof featureManager === "undefined") {}
-
-			clearInterval(featureManagerIntervalID);
-			resolve();
-		}, 100);
-	});
+	if ((await featureManagerLoaded()) !== true) {
+		return;
+	}
 
 	await requireElement("body");
 

--- a/extension/scripts/features/highlight-nerve-refill/ttHighlightNerveRefill.entry.ts
+++ b/extension/scripts/features/highlight-nerve-refill/ttHighlightNerveRefill.entry.ts
@@ -1,12 +1,7 @@
 (async () => {
-	await new Promise<void>((resolve) => {
-		const featureManagerIntervalID = setInterval(() => {
-			while (typeof featureManager === "undefined") {}
-
-			clearInterval(featureManagerIntervalID);
-			resolve();
-		}, 100);
-	});
+	if ((await featureManagerLoaded()) !== true) {
+		return;
+	}
 
 	await requireElement("body");
 


### PR DESCRIPTION
# Replace the pattern to compare featuremanagers type with undefined, since these scripts are loaded on **all** php pages, and they are run inside an interval, so they could spawn a lot of new promises doing the same thing if the feature manager is not going to start.

- [x] Read `CONTRIBUTING.md`.
- [ ] Added your name in `extension/scripts/global/team.ts` file.

Is this PR:
- [ ] for a new feature ?
- [x] an issue fix ?
- [ ] a developer QoL PR ?

**Purpose of PR:**
This relates to the previous PR I made about the Swagger hardly being able to load sometimes https://github.com/Mephiles/torntools_extension/pull/945

I think these could be the root cause of that. My syspision is that the feature manager will not start on pages like the swagger, but that the setIntervals in these features are starting new promises every 100ms, that all want to run their while loop, that does not yield at any point. So it locks up resources from the browser.

I found the featureManagerLoaded function inside the featureManager.ts file, and assumed that this was how to use it, given that it returns a promise<boolean>, and that I saw it used elsewhere. The other place did not check the return value. But given that these really need the featuremanager to be there, I opted to check the return value as well.

PS this is not an AI coded slop ticket, I just love the tool and want it to work better. I really have a lot of persormance issues on my phone & sometimes even on my PC

**Linked issues:**
None
