### PR TITLE
Update ttHideIcons.entry.ts to remove CPU-hungry while loop

### DIFF
--- a/extension/scripts/features/hide-icons/ttHideIcons.entry.ts
+++ b/extension/scripts/features/hide-icons/ttHideIcons.entry.ts
@@ -1,11 +1,16 @@
 (async () => {
-	await new Promise<void>((resolve) => {
+	await new Promise<void>((resolve, reject) => {
 		const featureManagerIntervalID = setInterval(() => {
-			while (typeof featureManager === "undefined") {}
+			if (typeof featureManager === "undefined") return;
 
 			clearInterval(featureManagerIntervalID);
 			resolve();
 		}, 100);
+		setTimeout(() => {
+			if (typeof featureManager !== "undefined") return;
+			clearInterval(featureManagerIntervalID);
+			reject(new Error("tt - FeatureManager not loaded."));
+		}, 10_000);
 	});
 
 	featureManager.registerFeature(


### PR DESCRIPTION
Let the featureManager check yield like it does in ttDisableAllyAttacksLoader.entry.ts and cancel the checks after 10s

- [x] Read `CONTRIBUTING.md`.
- [ ] Added your name in `extension/scripts/global/team.ts` file.

Is this PR:
- [ ] for a new feature ?
- [x] an issue fix ?
- [ ] a developer QoL PR ?

**Purpose of PR:**
* Remove cpu hungry while loop in interval
* Create a minimal timeout pattern

**Linked issues:**
https://github.com/Mephiles/torntools_extension/pull/946
