### PR TITLE
highlight-nerve-refill fix hungry CPU while-loop

### DIFF
--- a/extension/scripts/features/highlight-nerve-refill/ttHighlightNerveRefill.entry.ts
+++ b/extension/scripts/features/highlight-nerve-refill/ttHighlightNerveRefill.entry.ts
@@ -1,11 +1,11 @@
 (async () => {
 	await new Promise<void>((resolve) => {
 		const featureManagerIntervalID = setInterval(() => {
-			while (typeof featureManager === "undefined") {}
+			if (typeof featureManager === "undefined") return;
 
 			clearInterval(featureManagerIntervalID);
 			resolve();
-		}, 100);
+		}, 25);
 	});
 
 	await requireElement("body");


### PR DESCRIPTION
- [x] Read `CONTRIBUTING.md`.
- [ ] Added your name in `extension/scripts/global/team.ts` file.

Is this PR:
- [ ] for a new feature ?
- [x] an issue fix ?
- [ ] a developer QoL PR ?

**Purpose of PR:**
Replace while-loop with if-return to reduce the CPU hogging
Dialed down the interval to 25ms for faster startup, and compensation for the less eager if-check

**Linked issues:**
None
