### PR TITLE
#966 Add an async wait for the FF_SCOUTER_SERVICE initialization 

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -9,7 +9,8 @@
 				{ "message": "Resolve ff scouter errors on the profile blocking all actions.", "contributor": "DeKleineKobini" },
 				{ "message": "Fix features that load before page load often failing.", "contributor": "DeKleineKobini" },
 				{ "message": "Fix faction features appearing more than once on page load.", "contributor": "DeKleineKobini" },
-				{ "message": "Fix job points on icon hover after using them.", "contributor": "DeKleineKobini" }
+				{ "message": "Fix job points on icon hover after using them.", "contributor": "DeKleineKobini" },
+				{ "message": "Fix loading of FF_SCOUTER_SERVICE.", "contributor": "jensim" }
 			],
 			"changes": [
 				{ "message": "Track arson skill for the achievements.", "contributor": "DeKleineKobini" },

--- a/extension/scripts/features/ff-scouter/ff-scouter.ts
+++ b/extension/scripts/features/ff-scouter/ff-scouter.ts
@@ -134,11 +134,23 @@ class FFScouterService extends ScouterService {
 
 const FF_SCOUTER_SERVICE = new FFScouterService();
 
-function scouterService() {
+async function scouterService() {
 	const { ffScouter: useFFScouter } = settings.external;
 	if (!useFFScouter) {
 		return null;
 	}
+	await new Promise<void>((resolve) => {
+		const ffScouterServiceIntervalID = setInterval(() => {
+			if (!useFFScouter || !hasAPIData()) {
+				clearInterval(ffScouterServiceIntervalID);
+				resolve();
+				return;
+			} else if (typeof FF_SCOUTER_SERVICE === "undefined") return;
+
+			clearInterval(ffScouterServiceIntervalID);
+			resolve();
+		});
+	});
 
 	const services = [{ name: "ffscouter", service: FF_SCOUTER_SERVICE, check: useFFScouter && hasAPIData() }].filter((s) => s.check);
 

--- a/extension/scripts/features/ff-scouter/ttFFScouterAttack.ts
+++ b/extension/scripts/features/ff-scouter/ttFFScouterAttack.ts
@@ -1,7 +1,7 @@
 (async () => {
 	if (!getPageStatus().access) return;
 
-	const SCOUTER_SERVICE = scouterService();
+	const SCOUTER_SERVICE = await scouterService();
 
 	featureManager.registerFeature(
 		"FF Scouter Attack",

--- a/extension/scripts/features/ff-scouter/ttFFScouterFaction.ts
+++ b/extension/scripts/features/ff-scouter/ttFFScouterFaction.ts
@@ -1,7 +1,7 @@
 (async () => {
 	if (!getPageStatus().access) return;
 
-	const SCOUTER_SERVICE = scouterService();
+	const SCOUTER_SERVICE = await scouterService();
 
 	const feature = featureManager.registerFeature(
 		"FF Scouter Faction",

--- a/extension/scripts/features/ff-scouter/ttFFScouterGauge.ts
+++ b/extension/scripts/features/ff-scouter/ttFFScouterGauge.ts
@@ -14,7 +14,7 @@
 	let scoutLock = false;
 	let lockFailure = false;
 
-	const SCOUTER_SERVICE = scouterService();
+	const SCOUTER_SERVICE = await scouterService();
 
 	const feature = featureManager.registerFeature(
 		"FF Scouter Gauge",

--- a/extension/scripts/features/ff-scouter/ttFFScouterMiniProfile.ts
+++ b/extension/scripts/features/ff-scouter/ttFFScouterMiniProfile.ts
@@ -1,5 +1,5 @@
 (async () => {
-	const SCOUTER_SERVICE = scouterService();
+	const SCOUTER_SERVICE = await scouterService();
 
 	const feature = featureManager.registerFeature(
 		"FF Scouter Mini Profile",

--- a/extension/scripts/features/ff-scouter/ttFFScouterProfile.ts
+++ b/extension/scripts/features/ff-scouter/ttFFScouterProfile.ts
@@ -1,7 +1,7 @@
 (async () => {
 	if (!getPageStatus().access) return;
 
-	const SCOUTER_SERVICE = scouterService();
+	const SCOUTER_SERVICE = await scouterService();
 
 	featureManager.registerFeature(
 		"FF Scouter Profile",


### PR DESCRIPTION
Add a async wait for the FF_SCOUTER_SERVICE initialization to ensure it's ready, since it fails to load when browser optimizes it's loading

- [x] Read `CONTRIBUTING.md`.
- [x] Added your name in `extension/scripts/global/team.ts` file.
- [x] Update the unreleased version of `extension/changelog.js` file

Is this PR:
- [ ] for a new feature ?
- [x] an issue fix ?
- [ ] a developer QoL PR ?

**Purpose of PR:**

**Linked issues:**
#966 
