### PR TITLE
Remove feature log for FF Score filter

### DIFF
--- a/extension/changelog.json
+++ b/extension/changelog.json
@@ -24,7 +24,6 @@
 		"version": { "major": 8, "minor": 1, "build": 3 },
 		"date": "2026/03/04",
 		"logs": {
-			"features": [{ "message": "Add FF Score filter to the userlist and bounty filter.", "contributor": "jensim" }],
 			"fixes": [
 				{ "message": "Resolve ff scouter errors on the profile blocking all actions.", "contributor": "DeKleineKobini" },
 				{ "message": "Fix features that load before page load often failing.", "contributor": "DeKleineKobini" },


### PR DESCRIPTION
**Torn username and ID:**

- [x] Read `CONTRIBUTING.md`.
- [x] Added your name in `extension/scripts/global/team.ts` file.
- [x] Update the unreleased version of `extension/changelog.js` file

Is this PR:
- [ ] for a new feature ?
- [x] an issue fix ?
- [ ] a developer QoL PR ?

**Purpose of PR:**
Remove feature from changelog that was added post-release of 8.1.3.
This looks like it was added by mistake when merging different branches.

**Linked issues:**
None

<img width="934" height="155" alt="image" src="https://github.com/user-attachments/assets/6c26aa5c-d6f1-4014-93a6-e91adea6f817" />
https://github.com/Mephiles/torntools_extension/commit/a6a59873cf9e37b537aa4eda8a7db83d9520212d

<img width="1095" height="67" alt="image" src="https://github.com/user-attachments/assets/c9638dd6-dcbc-49d1-8e66-2a070c178e57" />
https://github.com/Mephiles/torntools_extension/commit/235f58c017e50683c8dfc520532367d4aa295ab2
