### PR TITLE
Fix Bun test alias resolution with explicit TypeScript paths

### DIFF
--- a/extension/utils/common/team.ts
+++ b/extension/utils/common/team.ts
@@ -331,6 +331,13 @@ export const TEAM: TeamMember[] = [
 		color: "#a6279b",
 	},
 	{
+		name: "Swervelord",
+		title: "Developer",
+		core: false,
+		torn: 3637232,
+		color: "#2E8B57",
+	},
+	{
 		name: "jensim",
 		title: "Developer",
 		core: false,

--- a/public/changelog.json
+++ b/public/changelog.json
@@ -16,7 +16,10 @@
 				{ "message": "Center 'Disable Ally Attacks' display text.", "contributor": "DeKleineKobini" }
 			],
 			"removed": [],
-			"technical": [{ "message": "Load the XHR and fetch script earlier, to catch more requests at the page load.", "contributor": "DeKleineKobini" }]
+			"technical": [
+				{ "message": "Load the XHR and fetch script earlier, to catch more requests at the page load.", "contributor": "DeKleineKobini" },
+				{ "message": "Add explicit TypeScript path mappings so Bun test resolves the extension's @ imports.", "contributor": "Swervelord" }
+			]
 		}
 	},
 	{

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
 	"extends": "./.wxt/tsconfig.json",
 	"compilerOptions": {
+		"paths": {
+			"@/*": ["./extension/*"],
+			"@features/*": ["./extension/utils/features/*"],
+			"@vendor/*": ["./extension/utils/vendor/*"]
+		},
 		"strictNullChecks": false,
 		"noImplicitAny": false,
 		"strictPropertyInitialization": false,


### PR DESCRIPTION
**Torn username and ID:**
Swervelord [3637232]

- [x] Read `CONTRIBUTING.md`.
- [x] Added your name in `extension/utils/common/team.ts`.
- [x] Update the unreleased version of `public/changelog.json`

Is this PR:
- [ ] for a new feature ?
- [ ] an issue fix ?
- [x] a developer QoL PR ?

**Purpose of PR:**
Add explicit TypeScript `paths` mappings so Bun resolves the repo's `@/...` imports when running tests from the repository root.

Also update the unreleased changelog entry and add Swervelord to the team metadata as required for a first contribution.

**Linked issues:**
None

**Validation:**
- `bun run test`
- `bunx tsc --noEmit --pretty false`