### PR TITLE
Show the absolute RW/OC start time in sidebar hover

### DIFF
--- a/src/common/features/oc2-time/oc2-time.ts
+++ b/src/common/features/oc2-time/oc2-time.ts
@@ -84,7 +84,6 @@ function buildTimeLeftElement() {
 		countdownTimers.push(timeLeftElement);
 	} else {
 		timeLeftElement.textContent = `Ready ${(userdata.organizedCrime as FactionCrime).status}`;
-		timeLeftElement.title = undefined;
 	}
 
 	return timeLeftElement;

--- a/src/common/features/oc2-time/oc2-time.ts
+++ b/src/common/features/oc2-time/oc2-time.ts
@@ -1,7 +1,7 @@
 import { settings, userdata } from "@common/utils/data/database";
 import { hasAPIData, hasOC2Data } from "@common/utils/functions/api";
 import { addInformationSection, checkDevice, elementBuilder, showInformationSection } from "@common/utils/functions/dom";
-import { type FormatTimeOptions, formatTime } from "@common/utils/functions/formatting";
+import { type FormatTimeOptions, formatDate, formatTime } from "@common/utils/functions/formatting";
 import { requireSidebar } from "@common/utils/functions/requires";
 import { countdownTimers } from "@common/utils/functions/timers";
 import { isPageWithSidebar, LINKS } from "@common/utils/functions/torn";
@@ -77,12 +77,14 @@ function buildTimeLeftElement() {
 	if (timeLeft > 0) {
 		const formatOptions: Partial<FormatTimeOptions> = { type: "wordTimer", extraShort: true, showDays: true, truncateSeconds: true };
 		timeLeftElement.textContent = formatTime({ milliseconds: timeLeft }, formatOptions);
+    timeLeftElement.title = `Ready at ${formatDate(readyAt, { showYear: true })} at ${formatTime(readyAt)}`;
 
 		timeLeftElement.dataset.end = readyAt.toString();
 		timeLeftElement.dataset.timeSettings = JSON.stringify(formatOptions);
 		countdownTimers.push(timeLeftElement);
 	} else {
-		timeLeftElement.textContent = `Ready ${(userdata.organizedCrime as FactionCrime).status}`;
+    timeLeftElement.textContent = `Ready ${(userdata.organizedCrime as FactionCrime).status}`;
+    timeLeftElement.title = undefined;
 	}
 
 	return timeLeftElement;

--- a/src/common/features/oc2-time/oc2-time.ts
+++ b/src/common/features/oc2-time/oc2-time.ts
@@ -77,14 +77,14 @@ function buildTimeLeftElement() {
 	if (timeLeft > 0) {
 		const formatOptions: Partial<FormatTimeOptions> = { type: "wordTimer", extraShort: true, showDays: true, truncateSeconds: true };
 		timeLeftElement.textContent = formatTime({ milliseconds: timeLeft }, formatOptions);
-    timeLeftElement.title = `Ready at ${formatDate(readyAt, { showYear: true })} at ${formatTime(readyAt)}`;
+		timeLeftElement.title = `Ready at ${formatDate(readyAt, { showYear: true })} at ${formatTime(readyAt)}`;
 
 		timeLeftElement.dataset.end = readyAt.toString();
 		timeLeftElement.dataset.timeSettings = JSON.stringify(formatOptions);
 		countdownTimers.push(timeLeftElement);
 	} else {
-    timeLeftElement.textContent = `Ready ${(userdata.organizedCrime as FactionCrime).status}`;
-    timeLeftElement.title = undefined;
+		timeLeftElement.textContent = `Ready ${(userdata.organizedCrime as FactionCrime).status}`;
+		timeLeftElement.title = undefined;
 	}
 
 	return timeLeftElement;

--- a/src/common/features/rw-timer/rw-timer.ts
+++ b/src/common/features/rw-timer/rw-timer.ts
@@ -1,7 +1,7 @@
 import { factiondata, settings, userdata } from "@common/utils/data/database";
 import { hasAPIData, hasOC2Data } from "@common/utils/functions/api";
 import { addInformationSection, checkDevice, elementBuilder, showInformationSection } from "@common/utils/functions/dom";
-import { type FormatTimeOptions, formatTime } from "@common/utils/functions/formatting";
+import { type FormatTimeOptions, formatDate, formatTime } from "@common/utils/functions/formatting";
 import { requireSidebar } from "@common/utils/functions/requires";
 import { countdownTimers } from "@common/utils/functions/timers";
 import { isPageWithSidebar, LINKS } from "@common/utils/functions/torn";
@@ -29,7 +29,7 @@ async function showTimer() {
 				elementBuilder({
 					type: "a",
 					class: "title",
-					text: "RW: ",
+          text: "RW: ",
 					href: LINKS.faction__ranked_war,
 				}),
 				buildTimeLeftElement(factiondata),
@@ -56,14 +56,16 @@ function buildTimeLeftElement(data: FetchedFactiondataBasic) {
 		else if (timeLeft <= TO_MILLIS.HOURS * 6) timeLeftElement.classList.add("medium");
 
 		const formatOptions: Partial<FormatTimeOptions> = { type: "wordTimer", extraShort: true, showDays: true, truncateSeconds: true };
-		timeLeftElement.textContent = formatTime({ milliseconds: timeLeft }, formatOptions);
+    timeLeftElement.textContent = formatTime({ milliseconds: timeLeft }, formatOptions);
+    timeLeftElement.title = `Starts at ${formatDate(startAt, { showYear: true })} at ${formatTime(startAt)}`;
 
 		timeLeftElement.dataset.end = startAt.toString();
 		timeLeftElement.dataset.timeSettings = JSON.stringify(formatOptions);
 		timeLeftElement.dataset.doneText = "Ongoing";
 		countdownTimers.push(timeLeftElement);
 	} else {
-		timeLeftElement.textContent = `Ongoing`;
+    timeLeftElement.textContent = `Ongoing`;
+    timeLeftElement.title = `Started at ${formatDate(startAt, { showYear: true })} at ${formatTime(startAt)}`;
 		timeLeftElement.classList.add("short");
 	}
 

--- a/src/common/features/rw-timer/rw-timer.ts
+++ b/src/common/features/rw-timer/rw-timer.ts
@@ -29,7 +29,7 @@ async function showTimer() {
 				elementBuilder({
 					type: "a",
 					class: "title",
-          text: "RW: ",
+					text: "RW: ",
 					href: LINKS.faction__ranked_war,
 				}),
 				buildTimeLeftElement(factiondata),
@@ -56,16 +56,16 @@ function buildTimeLeftElement(data: FetchedFactiondataBasic) {
 		else if (timeLeft <= TO_MILLIS.HOURS * 6) timeLeftElement.classList.add("medium");
 
 		const formatOptions: Partial<FormatTimeOptions> = { type: "wordTimer", extraShort: true, showDays: true, truncateSeconds: true };
-    timeLeftElement.textContent = formatTime({ milliseconds: timeLeft }, formatOptions);
-    timeLeftElement.title = `Starts at ${formatDate(startAt, { showYear: true })} at ${formatTime(startAt)}`;
+		timeLeftElement.textContent = formatTime({ milliseconds: timeLeft }, formatOptions);
+		timeLeftElement.title = `Starts at ${formatDate(startAt, { showYear: true })} at ${formatTime(startAt)}`;
 
 		timeLeftElement.dataset.end = startAt.toString();
 		timeLeftElement.dataset.timeSettings = JSON.stringify(formatOptions);
 		timeLeftElement.dataset.doneText = "Ongoing";
 		countdownTimers.push(timeLeftElement);
 	} else {
-    timeLeftElement.textContent = `Ongoing`;
-    timeLeftElement.title = `Started at ${formatDate(startAt, { showYear: true })} at ${formatTime(startAt)}`;
+		timeLeftElement.textContent = `Ongoing`;
+		timeLeftElement.title = `Started at ${formatDate(startAt, { showYear: true })} at ${formatTime(startAt)}`;
 		timeLeftElement.classList.add("short");
 	}
 

--- a/src/common/utils/team.ts
+++ b/src/common/utils/team.ts
@@ -344,6 +344,13 @@ export const TEAM: TeamMember[] = [
 		torn: 3737350,
 		color: "darkkhaki",
 	},
+	{
+		name: "RogerFar",
+		title: "Developer",
+		core: false,
+		torn: 4166912,
+		color: "#33873c",
+	},
 ];
 
 interface Contributor {

--- a/src/extension/assets/changelog.json
+++ b/src/extension/assets/changelog.json
@@ -7,7 +7,8 @@
 			"features": [
 				{ "message": "Use Torn Intel as (opt-in) source for the 'Travel Table'.", "contributor": "DeKleineKobini" },
 				{ "message": "Show faction stakeouts on the targets page.", "contributor": "DeKleineKobini" },
-				{ "message": "Show an indication for faction stakeouts that they are destroyed.", "contributor": "DeKleineKobini" }
+				{ "message": "Show an indication for faction stakeouts that they are destroyed.", "contributor": "DeKleineKobini" },
+        { "message": "Show the absolute time when a RW starts or OC is ready when hovering over the timer in the sidebar.", "contributor": "RogerFar" }
 			],
 			"fixes": [
 				{ "message": "Resolve an edge-case while force loading the database with an update already going on.", "contributor": "DeKleineKobini" },

--- a/src/extension/assets/changelog.json
+++ b/src/extension/assets/changelog.json
@@ -8,7 +8,7 @@
 				{ "message": "Use Torn Intel as (opt-in) source for the 'Travel Table'.", "contributor": "DeKleineKobini" },
 				{ "message": "Show faction stakeouts on the targets page.", "contributor": "DeKleineKobini" },
 				{ "message": "Show an indication for faction stakeouts that they are destroyed.", "contributor": "DeKleineKobini" },
-        { "message": "Show the absolute time when a RW starts or OC is ready when hovering over the timer in the sidebar.", "contributor": "RogerFar" }
+				{ "message": "Show the absolute time when a RW starts or OC is ready when hovering over the timer in the sidebar.", "contributor": "RogerFar" }
 			],
 			"fixes": [
 				{ "message": "Resolve an edge-case while force loading the database with an update already going on.", "contributor": "DeKleineKobini" },


### PR DESCRIPTION
…over the timer in the sidebar

**Torn username and ID:** 4166912

- [X] Read `CONTRIBUTING.md`.
- [X] Added your name in `extension/scripts/global/team.ts` file.
- [X] Update the unreleased version of `extension/changelog.js` file

Is this PR:
- [X] for a new feature ?
- [ ] an issue fix ?
- [ ] a developer QoL PR ?

**Purpose of PR:**
Often a RW is multiple days away, not easy to see what the actual date is. Instead of creating a 2nd label in the sidebar, I added a hover element for RW and OC2 that shows the absolute start time of an OC or RW.

**Linked issues:**
None
