### PR TITLE
Restore City Items map overlays

### DIFF
--- a/src/common/features/city-items/city-items-map.ts
+++ b/src/common/features/city-items/city-items-map.ts
@@ -1,0 +1,396 @@
+export const CITY_ITEMS_MAP_EVENTS = {
+	SET_ITEMS: "tt-city-items:set-items",
+	REQUEST_MODEL_ITEMS: "tt-city-items:request-model-items",
+	MODEL_ITEMS: "tt-city-items:model-items",
+	CLEAR: "tt-city-items:clear",
+} as const;
+
+export interface CityItemsMapEntry {
+	entryId: string;
+	itemId: number;
+	name: string;
+	td: string;
+	x: number;
+	y: number;
+}
+
+interface LeafletLatLng {
+	lat: number;
+	lng: number;
+}
+
+type LeafletLatLngLike = LeafletLatLng | [number, number];
+
+type LeafletPoint = unknown;
+
+interface LeafletMap {
+	addLayer(layer: LeafletMarker): unknown;
+	removeLayer?(layer: LeafletMarker): void;
+}
+
+type LeafletIcon = object;
+
+interface LeafletMarker {
+	_map?: LeafletMap;
+	setLatLng?(latLng: LeafletLatLngLike): this;
+	addTo?(map: LeafletMap): this;
+	remove?(): this;
+	removeFrom?(map: LeafletMap | null): this;
+	getElement?(): HTMLElement | null;
+}
+
+interface LeafletDivIconOptions {
+	className: string;
+	html: string;
+	iconSize: [number, number];
+	iconAnchor: [number, number];
+}
+
+interface LeafletMarkerOptions {
+	icon: LeafletIcon;
+	interactive: boolean;
+	keyboard: boolean;
+	zIndexOffset: number;
+}
+
+interface LeafletRuntime {
+	divIcon?(options: LeafletDivIconOptions): LeafletIcon;
+	marker?(latLng: LeafletLatLngLike, options: LeafletMarkerOptions): LeafletMarker;
+	CRS?: {
+		EPSG3857?: {
+			pointToLatLng(point: LeafletPoint, zoom?: number): LeafletLatLngLike;
+		};
+	};
+}
+
+interface LeafletOverlayRuntime extends LeafletRuntime {
+	divIcon(options: LeafletDivIconOptions): LeafletIcon;
+	marker(latLng: LeafletLatLngLike, options: LeafletMarkerOptions): LeafletMarker;
+}
+
+interface TornMapRuntime {
+	lmap?: LeafletMap;
+	minZoom?: number;
+	getLPoint?(point: [number, number]): LeafletPoint;
+}
+
+interface TornModelRuntime {
+	get(): { territoryUserItems?: unknown[] } | null | undefined;
+	get(key: "territoryUserItems"): unknown[] | null | undefined;
+}
+
+interface TornRuntime {
+	map?: TornMapRuntime;
+	model?: TornModelRuntime;
+}
+
+interface CityItemsMapWindow extends Window {
+	L?: LeafletRuntime;
+	__ttCityItemsMap?: CityItemsMapState;
+}
+
+interface LeafletMapElement extends HTMLElement {
+	_leaflet_map?: LeafletMap;
+}
+
+interface OverlayRecord {
+	entry: CityItemsMapEntry;
+	marker: LeafletMarker | null;
+	latLng?: LeafletLatLngLike;
+}
+
+interface CityItemsMapState {
+	injected: boolean;
+	entries: CityItemsMapEntry[];
+	overlays: Map<string, OverlayRecord>;
+	syncTimer?: number;
+}
+
+const BASE_HIGHLIGHT_SIZE = 38;
+const SYNC_ATTEMPT_INTERVAL = 250;
+const SYNC_ATTEMPT_LIMIT = 80;
+
+export function injectCityItemsMapListeners(pageWindow: CityItemsMapWindow = window) {
+	if (pageWindow.__ttCityItemsMap?.injected) return;
+
+	const state: CityItemsMapState = {
+		injected: true,
+		entries: [],
+		overlays: new Map(),
+	};
+	pageWindow.__ttCityItemsMap = state;
+
+	pageWindow.addEventListener(CITY_ITEMS_MAP_EVENTS.SET_ITEMS, handleSetItemsEvent);
+	pageWindow.addEventListener(CITY_ITEMS_MAP_EVENTS.REQUEST_MODEL_ITEMS, () => {
+		const items = getModelItems();
+		dispatchPageEvent(CITY_ITEMS_MAP_EVENTS.MODEL_ITEMS, { items });
+	});
+	pageWindow.addEventListener(CITY_ITEMS_MAP_EVENTS.CLEAR, clearOverlays);
+
+	function handleSetItemsEvent(event: Event) {
+		const detail = parseEventDetail<{ entries?: unknown }>(event);
+		if (!detail) return;
+
+		state.entries = Array.isArray(detail.entries) ? detail.entries.filter(isCityItemsMapEntry) : [];
+		scheduleSync();
+	}
+
+	function scheduleSync() {
+		let attempts = 0;
+		syncOverlays();
+		if (state.syncTimer) return;
+
+		state.syncTimer = pageWindow.setInterval(() => {
+			attempts++;
+			const synced = syncOverlays();
+			if (synced || attempts >= SYNC_ATTEMPT_LIMIT || !state.entries.length) {
+				if (state.syncTimer) pageWindow.clearInterval(state.syncTimer);
+				state.syncTimer = undefined;
+			}
+		}, SYNC_ATTEMPT_INTERVAL);
+	}
+
+	function syncOverlays(): boolean {
+		const map = getMap();
+		const L = pageWindow.L;
+		if (!map || !isLeafletOverlayRuntime(L)) return false;
+
+		const activeEntryIds = new Set(state.entries.map((entry) => entry.entryId));
+
+		for (const [entryId, record] of state.overlays) {
+			if (!activeEntryIds.has(entryId)) {
+				removeOverlay(record);
+				state.overlays.delete(entryId);
+			}
+		}
+
+		for (const entry of state.entries) {
+			let record = state.overlays.get(entry.entryId);
+			const latLng = getLatLngForEntry(entry);
+			if (!latLng) continue;
+
+			if (!record) {
+				record = { entry, marker: null, latLng };
+				state.overlays.set(entry.entryId, record);
+			} else {
+				record.entry = entry;
+				record.latLng = latLng;
+			}
+
+			ensureOverlay(record, map, L);
+		}
+
+		return state.entries.every((entry) => !!state.overlays.get(entry.entryId)?.marker);
+	}
+
+	function ensureOverlay(record: OverlayRecord, map: LeafletMap, L: LeafletOverlayRuntime) {
+		const latLng = record.latLng;
+		if (!latLng) return;
+
+		try {
+			if (record.marker?._map && record.marker._map !== map) removeOverlay(record);
+
+			if (record.marker) {
+				record.marker.setLatLng?.(latLng);
+				updateOverlayElement(record);
+				return;
+			}
+
+			const icon = L.divIcon({
+				className: "tt-city-item-overlay city-item",
+				html: `<span class="tt-city-item-overlay-content"><img src="${getItemImageUrl(record.entry.itemId)}" alt=""></span>`,
+				iconSize: [BASE_HIGHLIGHT_SIZE, BASE_HIGHLIGHT_SIZE],
+				iconAnchor: [BASE_HIGHLIGHT_SIZE / 2, BASE_HIGHLIGHT_SIZE / 2],
+			});
+
+			const marker = L.marker(latLng, {
+				icon,
+				interactive: true,
+				keyboard: false,
+				zIndexOffset: 1000,
+			});
+			if (typeof marker.addTo !== "function") return;
+
+			marker.addTo(map);
+			record.marker = marker;
+			updateOverlayElement(record);
+		} catch {
+			record.marker = null;
+		}
+	}
+
+	function updateOverlayElement(record: OverlayRecord) {
+		const element = record.marker?.getElement?.();
+		if (!element) return;
+
+		element.classList.add("tt-city-item-overlay", "city-item");
+		element.dataset.id = record.entry.itemId.toString();
+		element.dataset.itemId = record.entry.itemId.toString();
+		element.dataset.entryId = record.entry.entryId;
+		element.dataset.td = record.entry.td;
+		element.removeAttribute("title");
+	}
+
+	function clearOverlays() {
+		state.entries = [];
+		if (state.syncTimer) {
+			pageWindow.clearInterval(state.syncTimer);
+			state.syncTimer = undefined;
+		}
+		for (const record of state.overlays.values()) removeOverlay(record);
+		state.overlays.clear();
+	}
+
+	function removeOverlay(record: OverlayRecord) {
+		if (!record.marker) return;
+
+		try {
+			if (record.marker.remove) record.marker.remove();
+			else record.marker.removeFrom?.(getMap());
+		} catch {
+			try {
+				record.marker._map?.removeLayer?.(record.marker);
+			} catch {}
+		}
+		record.marker = null;
+	}
+
+	function getMap(): LeafletMap | null {
+		const mapElement = pageWindow.document.querySelector<LeafletMapElement>("#map");
+		const map = getTornRuntime()?.map?.lmap ?? mapElement?._leaflet_map;
+		return isLeafletMap(map) ? map : null;
+	}
+
+	function getLatLngForEntry(entry: CityItemsMapEntry): LeafletLatLngLike | null {
+		if (!Number.isFinite(entry.x) || !Number.isFinite(entry.y)) return null;
+
+		const tornMap = getTornRuntime()?.map;
+		const L = pageWindow.L;
+		try {
+			if (tornMap?.getLPoint && L?.CRS?.EPSG3857?.pointToLatLng) {
+				const point: [number, number] = [entry.x / 2, entry.y / 2];
+				const leafletPoint = tornMap.getLPoint(point);
+				return normalizeLatLng(L.CRS.EPSG3857.pointToLatLng(leafletPoint, tornMap.minZoom));
+			}
+		} catch {}
+
+		return null;
+	}
+
+	function getModelItems(): unknown[] {
+		const model = getTornRuntime()?.model;
+		if (!model) return [];
+
+		try {
+			const fullModel = model.get();
+			if (Array.isArray(fullModel?.territoryUserItems)) return fullModel.territoryUserItems;
+		} catch {}
+
+		try {
+			const userItems = model.get("territoryUserItems");
+			if (Array.isArray(userItems)) return userItems;
+		} catch {}
+
+		return [];
+	}
+
+	function getTornRuntime(): TornRuntime | null {
+		const torn: unknown = pageWindow.torn;
+		return isTornRuntime(torn) ? torn : null;
+	}
+
+	function dispatchPageEvent(name: (typeof CITY_ITEMS_MAP_EVENTS)[keyof typeof CITY_ITEMS_MAP_EVENTS], detail?: unknown) {
+		pageWindow.dispatchEvent(new CustomEvent(name, { detail: serializeEventDetail(detail) }));
+	}
+}
+
+function parseEventDetail<T>(event: Event): T | null {
+	if (!isCustomEvent<unknown>(event)) return null;
+
+	if (typeof event.detail === "string") {
+		try {
+			return JSON.parse(event.detail) as T;
+		} catch {
+			return null;
+		}
+	}
+
+	return event.detail as T;
+}
+
+function serializeEventDetail(detail: unknown): string | undefined {
+	if (detail === undefined) return undefined;
+
+	try {
+		return JSON.stringify(detail);
+	} catch {
+		return undefined;
+	}
+}
+
+function isCustomEvent<T>(event: Event): event is CustomEvent<T> {
+	return "detail" in event;
+}
+
+function isCityItemsMapEntry(value: unknown): value is CityItemsMapEntry {
+	return (
+		isRecord(value) &&
+		typeof value.entryId === "string" &&
+		typeof value.itemId === "number" &&
+		Number.isFinite(value.itemId) &&
+		typeof value.name === "string" &&
+		typeof value.td === "string" &&
+		typeof value.x === "number" &&
+		Number.isFinite(value.x) &&
+		typeof value.y === "number" &&
+		Number.isFinite(value.y)
+	);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isTornRuntime(value: unknown): value is TornRuntime {
+	return (
+		isRecord(value) &&
+		(!("map" in value) || value.map == null || isTornMapRuntime(value.map)) &&
+		(!("model" in value) || value.model == null || isTornModelRuntime(value.model))
+	);
+}
+
+function isTornMapRuntime(value: unknown): value is TornMapRuntime {
+	return (
+		isRecord(value) &&
+		(!("lmap" in value) || value.lmap == null || isLeafletMap(value.lmap)) &&
+		(!("minZoom" in value) || value.minZoom == null || typeof value.minZoom === "number") &&
+		(!("getLPoint" in value) || value.getLPoint == null || typeof value.getLPoint === "function")
+	);
+}
+
+function isTornModelRuntime(value: unknown): value is TornModelRuntime {
+	return isRecord(value) && typeof value.get === "function";
+}
+
+function isLeafletMap(value: unknown): value is LeafletMap {
+	return isRecord(value) && typeof value.addLayer === "function";
+}
+
+function isLeafletOverlayRuntime(value: unknown): value is LeafletOverlayRuntime {
+	return isRecord(value) && typeof value.divIcon === "function" && typeof value.marker === "function";
+}
+
+function normalizeLatLng(latLng: LeafletLatLngLike | null | undefined): LeafletLatLngLike | null {
+	if (!latLng) return null;
+
+	if (Array.isArray(latLng)) {
+		const [lat, lng] = latLng;
+		return Number.isFinite(lat) && Number.isFinite(lng) ? latLng : null;
+	}
+
+	return Number.isFinite(latLng.lat) && Number.isFinite(latLng.lng) ? latLng : null;
+}
+
+function getItemImageUrl(itemId: number): string {
+	return `https://www.torn.com/images/items/${itemId}/small.png`;
+}

--- a/src/common/features/city-items/city-items-map.ts
+++ b/src/common/features/city-items/city-items-map.ts
@@ -1,3 +1,5 @@
+import type { InternalCityItem, TornCityMapRuntime, TornCityObject } from "@common/pages/city-page";
+
 export const CITY_ITEMS_MAP_EVENTS = {
 	SET_ITEMS: "tt-city-items:set-items",
 	REQUEST_MODEL_ITEMS: "tt-city-items:request-model-items",
@@ -68,21 +70,14 @@ interface LeafletOverlayRuntime extends LeafletRuntime {
 	marker(latLng: LeafletLatLngLike, options: LeafletMarkerOptions): LeafletMarker;
 }
 
-interface TornMapRuntime {
+interface TornMapRuntime extends TornCityMapRuntime {
 	lmap?: LeafletMap;
-	minZoom?: number;
 	getLPoint?(point: [number, number]): LeafletPoint;
 }
 
-interface TornModelRuntime {
-	get(): { territoryUserItems?: unknown[] } | null | undefined;
-	get(key: "territoryUserItems"): unknown[] | null | undefined;
-}
-
-interface TornRuntime {
+type TornRuntime = Partial<Pick<TornCityObject, "model">> & {
 	map?: TornMapRuntime;
-	model?: TornModelRuntime;
-}
+};
 
 interface CityItemsMapWindow extends Window {
 	L?: LeafletRuntime;
@@ -277,7 +272,7 @@ export function injectCityItemsMapListeners(pageWindow: CityItemsMapWindow = win
 		return null;
 	}
 
-	function getModelItems(): unknown[] {
+	function getModelItems(): InternalCityItem[] {
 		const model = getTornRuntime()?.model;
 		if (!model) return [];
 
@@ -368,7 +363,7 @@ function isTornMapRuntime(value: unknown): value is TornMapRuntime {
 	);
 }
 
-function isTornModelRuntime(value: unknown): value is TornModelRuntime {
+function isTornModelRuntime(value: unknown): value is TornCityObject["model"] {
 	return isRecord(value) && typeof value.get === "function";
 }
 

--- a/src/common/features/city-items/city-items-map.ts
+++ b/src/common/features/city-items/city-items-map.ts
@@ -147,8 +147,8 @@ export function injectCityItemsMapListeners(pageWindow: CityItemsMapWindow = win
 
 	function syncOverlays(): boolean {
 		const map = getMap();
-		const L = pageWindow.L;
-		if (!map || !isLeafletOverlayRuntime(L)) return false;
+		const leaflet = pageWindow.L;
+		if (!map || !isLeafletOverlayRuntime(leaflet)) return false;
 
 		const activeEntryIds = new Set(state.entries.map((entry) => entry.entryId));
 
@@ -172,13 +172,13 @@ export function injectCityItemsMapListeners(pageWindow: CityItemsMapWindow = win
 				record.latLng = latLng;
 			}
 
-			ensureOverlay(record, map, L);
+			ensureOverlay(record, map, leaflet);
 		}
 
 		return state.entries.every((entry) => !!state.overlays.get(entry.entryId)?.marker);
 	}
 
-	function ensureOverlay(record: OverlayRecord, map: LeafletMap, L: LeafletOverlayRuntime) {
+	function ensureOverlay(record: OverlayRecord, map: LeafletMap, leaflet: LeafletOverlayRuntime) {
 		const latLng = record.latLng;
 		if (!latLng) return;
 
@@ -191,14 +191,14 @@ export function injectCityItemsMapListeners(pageWindow: CityItemsMapWindow = win
 				return;
 			}
 
-			const icon = L.divIcon({
+			const icon = leaflet.divIcon({
 				className: "tt-city-item-overlay city-item",
 				html: `<span class="tt-city-item-overlay-content"><img src="${getItemImageUrl(record.entry.itemId)}" alt=""></span>`,
 				iconSize: [BASE_HIGHLIGHT_SIZE, BASE_HIGHLIGHT_SIZE],
 				iconAnchor: [BASE_HIGHLIGHT_SIZE / 2, BASE_HIGHLIGHT_SIZE / 2],
 			});
 
-			const marker = L.marker(latLng, {
+			const marker = leaflet.marker(latLng, {
 				icon,
 				interactive: true,
 				keyboard: false,
@@ -260,12 +260,12 @@ export function injectCityItemsMapListeners(pageWindow: CityItemsMapWindow = win
 		if (!Number.isFinite(entry.x) || !Number.isFinite(entry.y)) return null;
 
 		const tornMap = getTornRuntime()?.map;
-		const L = pageWindow.L;
+		const leaflet = pageWindow.L;
 		try {
-			if (tornMap?.getLPoint && L?.CRS?.EPSG3857?.pointToLatLng) {
+			if (tornMap?.getLPoint && leaflet?.CRS?.EPSG3857?.pointToLatLng) {
 				const point: [number, number] = [entry.x / 2, entry.y / 2];
 				const leafletPoint = tornMap.getLPoint(point);
-				return normalizeLatLng(L.CRS.EPSG3857.pointToLatLng(leafletPoint, tornMap.minZoom));
+				return normalizeLatLng(leaflet.CRS.EPSG3857.pointToLatLng(leafletPoint, tornMap.minZoom));
 			}
 		} catch {}
 

--- a/src/common/features/city-items/city-items.css
+++ b/src/common/features/city-items/city-items.css
@@ -48,14 +48,12 @@
 }
 
 #map .tt-city-item-overlay.city-item:hover,
-#map .tt-city-item-overlay.city-item.force-hover,
-#map .tt-city-item-overlay.city-item.search-hover {
+#map .tt-city-item-overlay.city-item.force-hover {
 	z-index: 1000 !important;
 }
 
 #map .tt-city-item-overlay.city-item:hover .tt-city-item-overlay-content,
-#map .tt-city-item-overlay.city-item.force-hover .tt-city-item-overlay-content,
-#map .tt-city-item-overlay.city-item.search-hover .tt-city-item-overlay-content {
+#map .tt-city-item-overlay.city-item.force-hover .tt-city-item-overlay-content {
 	width: 62px;
 	height: 62px;
 	padding: 8px;
@@ -84,7 +82,7 @@
 	letter-spacing: 0.2px;
 }
 
-.tt-city-items span:nth-of-type(odd) {
+.tt-city-items p > span:nth-of-type(odd) {
 	color: #aaa;
 }
 
@@ -92,14 +90,116 @@
 	cursor: pointer;
 }
 
-.tt-city-search {
+.tt-city-controls {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	align-items: center;
+	width: 100%;
+	margin-bottom: 4px;
+	padding: 6px 0;
+	border-bottom: 1px solid var(--default-panel-divider-outer-side-color);
+}
+
+.tt-city-group-filter,
+.tt-city-period-filter,
+.tt-city-search-filter {
 	display: flex;
 	align-items: center;
+	justify-content: center;
 	gap: 6px;
+	min-width: 0;
+	padding: 0 10px;
+}
+
+.tt-city-controls > * + * {
+	border-left: 1px solid var(--default-panel-divider-inner-side-color);
+}
+
+.tt-city-control-label {
+	white-space: nowrap;
+}
+
+.tt-city-group-filter .tt-checkbox-wrapper {
+	display: inline-flex;
+}
+
+.tt-city-period-group {
 	margin-top: 6px;
 }
 
-.tt-city-search input {
+.tt-city-period-header {
+	display: flex;
+	align-items: baseline;
+	flex-wrap: wrap;
+	gap: 4px;
+	font-weight: bold;
+	margin-bottom: 2px;
+}
+
+.tt-city-period-count {
+	color: #aaa;
+	font-weight: normal;
+}
+
+.tt-city-period-value {
+	margin-left: auto;
+	color: var(--tt-color-item-text);
+	font-weight: normal;
+}
+
+.tt-city-group-pagination {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-top: 6px;
+	padding-top: 6px;
+	border-top: 1px solid var(--default-panel-divider-inner-side-color);
+	color: var(--default-color);
+}
+
+.tt-city-group-pagination-button {
+	border: none;
+	background: transparent;
+	font: inherit;
+	padding: 0;
+}
+
+.tt-city-controls select,
+.tt-city-search-filter input {
+	max-width: 100%;
+}
+
+.tt-city-search-filter input {
+	width: 180px;
+	min-width: 90px;
+}
+
+body.tt-mobile .tt-city-controls > *,
+body.tt-tablet .tt-city-controls > * {
+	align-items: stretch;
+	flex-direction: column;
+	gap: 4px;
+	padding: 0 6px;
+}
+
+body.tt-mobile .tt-city-group-filter,
+body.tt-tablet .tt-city-group-filter {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	align-items: center;
+}
+
+body.tt-mobile .tt-city-group-filter .tt-city-control-label,
+body.tt-tablet .tt-city-group-filter .tt-city-control-label {
+	grid-column: 1 / -1;
+}
+
+body.tt-mobile .tt-city-controls select,
+body.tt-tablet .tt-city-controls select,
+body.tt-mobile .tt-city-search-filter input,
+body.tt-tablet .tt-city-search-filter input {
+	width: 100%;
 	min-width: 0;
-	flex: 1;
 }

--- a/src/common/features/city-items/city-items.css
+++ b/src/common/features/city-items/city-items.css
@@ -1,26 +1,105 @@
+/*
+ * Credits to Mauk / DoctorN for the original TornTools city item highlight style.
+ */
+#map .tt-city-item-overlay.city-item {
+	box-sizing: border-box;
+	display: block !important;
+	width: 38px !important;
+	height: 38px !important;
+	margin-left: -19px !important;
+	margin-top: -19px !important;
+	z-index: 999 !important;
+	border: none;
+	background: transparent;
+	cursor: pointer;
+	pointer-events: auto !important;
+}
+
+#map .tt-city-item-overlay.city-item .tt-city-item-overlay-content {
+	box-sizing: border-box;
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 38px;
+	height: 38px;
+	padding: 6px;
+	border-radius: 100%;
+	background: rgba(0, 0, 0, 0.45);
+	box-shadow:
+		0 0 0 1px rgba(255, 255, 255, 0.25),
+		rgb(0, 0, 0) 0 0 9px 4px;
+	transform: translate(-50%, -50%);
+	transition:
+		width 50ms cubic-bezier(0.65, 0.05, 0.36, 1),
+		height 50ms cubic-bezier(0.65, 0.05, 0.36, 1),
+		padding 50ms cubic-bezier(0.65, 0.05, 0.36, 1),
+		box-shadow 50ms cubic-bezier(0.65, 0.05, 0.36, 1),
+		background 50ms 0ms;
+}
+
+#map .tt-city-item-overlay.city-item img {
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+	pointer-events: none;
+}
+
+#map .tt-city-item-overlay.city-item:hover,
+#map .tt-city-item-overlay.city-item.force-hover,
+#map .tt-city-item-overlay.city-item.search-hover {
+	z-index: 1000 !important;
+}
+
+#map .tt-city-item-overlay.city-item:hover .tt-city-item-overlay-content,
+#map .tt-city-item-overlay.city-item.force-hover .tt-city-item-overlay-content,
+#map .tt-city-item-overlay.city-item.search-hover .tt-city-item-overlay-content {
+	width: 62px;
+	height: 62px;
+	padding: 8px;
+	background: rgba(0, 0, 0, 0.72);
+	box-shadow:
+		0 0 0 2px rgba(255, 255, 255, 0.35),
+		rgb(0, 0, 0) 0 0 12px 5px;
+}
+
 .tt-city-total {
 	font-size: 14px;
 	margin-bottom: 2px;
+}
 
-	.tt-city-total-text {
-		font-weight: bold;
-	}
+.tt-city-total .tt-city-total-text {
+	font-weight: bold;
+}
 
-	.tt-city-total-value {
-		color: var(--tt-color-item-text);
-	}
+.tt-city-total .tt-city-total-value {
+	color: var(--tt-color-item-text);
 }
 
 .tt-city-items {
 	line-height: 14px;
 	/*noinspection CssNonIntegerLengthInPixels*/
 	letter-spacing: 0.2px;
+}
 
-	span:nth-of-type(odd) {
-		color: #aaa;
-	}
+.tt-city-items span:nth-of-type(odd) {
+	color: #aaa;
+}
 
-	.list-item {
-		cursor: pointer;
-	}
+.tt-city-items .list-item {
+	cursor: pointer;
+}
+
+.tt-city-search {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin-top: 6px;
+}
+
+.tt-city-search input {
+	min-width: 0;
+	flex: 1;
 }

--- a/src/common/features/city-items/city-items.ts
+++ b/src/common/features/city-items/city-items.ts
@@ -39,7 +39,7 @@ let visibleGroupCount = GROUP_PAGE_SIZE;
 const collectingEntries = new Set<string>();
 
 function initialise() {
-	SCRIPT_INJECTOR.injectCityItemsMap?.();
+	SCRIPT_INJECTOR.injectCityItemsMap();
 
 	addXHRListener(({ detail: { page, xhr, json } }) => {
 		if (!FEATURE_MANAGER.isEnabled(CityItemsFeature)) return;
@@ -69,7 +69,7 @@ function triggerFallback() {
 		return;
 	}
 
-	SCRIPT_INJECTOR.injectCityItemsMap?.();
+	SCRIPT_INJECTOR.injectCityItemsMap();
 	window.setTimeout(() => dispatchMapEvent(CITY_ITEMS_MAP_EVENTS.REQUEST_MODEL_ITEMS), 100);
 }
 

--- a/src/common/features/city-items/city-items.ts
+++ b/src/common/features/city-items/city-items.ts
@@ -2,6 +2,8 @@ import "./city-items.css";
 import { type DecodedCityItem, type InternalCityItem, isMapData } from "@common/pages/city-page";
 import { FEATURE_MANAGER, ITEM_RESOLVER, SCRIPT_INJECTOR, ttStorage } from "@common/utils/context";
 import { settings } from "@common/utils/data/database";
+import { createCheckbox } from "@common/utils/elements/checkbox/checkbox";
+import { createSelect } from "@common/utils/elements/select/select";
 import { displayAlert } from "@common/utils/functions/alerts";
 import { fetchData } from "@common/utils/functions/api-fetcher";
 import { createContainer, findContainer, removeContainer } from "@common/utils/functions/containers";
@@ -9,10 +11,8 @@ import { elementBuilder, findAllElements } from "@common/utils/functions/dom";
 import { formatDate, formatNumber } from "@common/utils/functions/formatting";
 import { addXHRListener } from "@common/utils/functions/listeners";
 import { requireElement } from "@common/utils/functions/requires";
-import { MONTHS } from "@common/utils/functions/utilities";
-import { createCheckbox } from "@common/utils/elements/checkbox/checkbox";
-import { createSelect } from "@common/utils/elements/select/select";
 import { getPageStatus } from "@common/utils/functions/torn";
+import { MONTHS } from "@common/utils/functions/utilities";
 import type { FullItem } from "@common/utils/torn-api/items.types";
 import { ExecutionTiming, Feature } from "@features/feature";
 import { CITY_ITEMS_MAP_EVENTS, type CityItemsMapEntry } from "./city-items-map";
@@ -427,10 +427,7 @@ function showControls(content: HTMLElement, items: CityItem[]) {
 
 	const bandOrder = getBandOrder();
 	const presentBands = bandOrder.filter((band) => items.some((item) => item.entries.some((entry) => getBandForTimestamp(entry.timestamp) === band)));
-	const bandOptions = [
-		{ value: "all", description: "All" },
-		...presentBands.map((band) => ({ value: band, description: formatBandLabel(band) })),
-	];
+	const bandOptions = [{ value: "all", description: "All" }, ...presentBands.map((band) => ({ value: band, description: formatBandLabel(band) }))];
 	const periodSelect = createSelect(bandOptions);
 	if (!periodSelect.setSelected(periodFilter)) {
 		periodSelect.setSelected("all");
@@ -465,7 +462,11 @@ function showControls(content: HTMLElement, items: CityItem[]) {
 				elementBuilder({
 					type: "div",
 					class: "tt-city-group-filter",
-					children: [elementBuilder({ type: "span", class: "tt-city-control-label", text: "Group:" }), groupByCheckbox.element, groupBySelect.element],
+					children: [
+						elementBuilder({ type: "span", class: "tt-city-control-label", text: "Group:" }),
+						groupByCheckbox.element,
+						groupBySelect.element,
+					],
 				}),
 				elementBuilder({
 					type: "label",
@@ -623,7 +624,13 @@ function appendItemsParagraph(parent: HTMLElement, items: CityItem[], withPreamb
 
 	const children: (string | HTMLElement)[] = [];
 	if (withPreamble) {
-		children.push("There", totalCount === 1 ? " is " : " are ", elementBuilder({ type: "strong", text: String(totalCount) }), totalCount === 1 ? " item " : " items ", "in the city: ");
+		children.push(
+			"There",
+			totalCount === 1 ? " is " : " are ",
+			elementBuilder({ type: "strong", text: String(totalCount) }),
+			totalCount === 1 ? " item " : " items ",
+			"in the city: ",
+		);
 	}
 
 	const paragraph = elementBuilder({ type: "p", children });

--- a/src/common/features/city-items/city-items.ts
+++ b/src/common/features/city-items/city-items.ts
@@ -1,6 +1,6 @@
 import "./city-items.css";
 import { type DecodedCityItem, type InternalCityItem, isMapData } from "@common/pages/city-page";
-import { FEATURE_MANAGER, ITEM_RESOLVER, SCRIPT_INJECTOR } from "@common/utils/context";
+import { FEATURE_MANAGER, ITEM_RESOLVER, SCRIPT_INJECTOR, ttStorage } from "@common/utils/context";
 import { settings } from "@common/utils/data/database";
 import { displayAlert } from "@common/utils/functions/alerts";
 import { fetchData } from "@common/utils/functions/api-fetcher";
@@ -9,24 +9,32 @@ import { elementBuilder, findAllElements } from "@common/utils/functions/dom";
 import { formatNumber } from "@common/utils/functions/formatting";
 import { addXHRListener } from "@common/utils/functions/listeners";
 import { requireElement } from "@common/utils/functions/requires";
+import { createCheckbox } from "@common/utils/elements/checkbox/checkbox";
+import { createSelect } from "@common/utils/elements/select/select";
 import { getPageStatus } from "@common/utils/functions/torn";
 import type { FullItem } from "@common/utils/torn-api/items.types";
 import { ExecutionTiming, Feature } from "@features/feature";
 import { CITY_ITEMS_MAP_EVENTS, type CityItemsMapEntry } from "./city-items-map";
 
 const ENCODING_NUMERIC_SYSTEM = 36;
+const GROUP_PAGE_SIZE = 10;
 
-type CityItemEntry = CityItemsMapEntry;
+type CityItemEntry = CityItemsMapEntry & { timestamp: number };
 
 interface CityItem {
 	item: number;
 	count: number;
 	name: string;
 	entries: CityItemEntry[];
+	timestamp: number;
+	band: string;
 }
 
 let contentElement: HTMLElement | null = null;
 let currentItems: CityItem[] = [];
+let periodFilter = "all";
+let searchQuery = "";
+let visibleGroupCount = GROUP_PAGE_SIZE;
 const collectingEntries = new Set<string>();
 
 function initialise() {
@@ -100,11 +108,11 @@ function isInternalCityItem(value: unknown): value is InternalCityItem {
 		isRecord(value) &&
 		Array.isArray(value.coordinates) &&
 		value.coordinates.length >= 2 &&
-		typeof value.coordinates[0] === "number" &&
-		typeof value.coordinates[1] === "number" &&
-		typeof value.item_id === "number" &&
-		typeof value.row_id === "number" &&
-		typeof value.timestamp === "number" &&
+		Number.isFinite(value.coordinates[0]) &&
+		Number.isFinite(value.coordinates[1]) &&
+		Number.isFinite(value.item_id) &&
+		Number.isFinite(value.row_id) &&
+		Number.isFinite(value.timestamp) &&
 		typeof value.title === "string"
 	);
 }
@@ -155,7 +163,10 @@ function resolveUserItems(decodedItems: (DecodedCityItem | InternalCityItem)[]):
 		const id = getCityItemId(item);
 		if (!Number.isFinite(id)) return;
 
-		const entry = getCityItemEntry(item, id);
+		const timestamp = getItemTimestamp(item);
+		if (!Number.isFinite(timestamp)) return;
+
+		const entry = getCityItemEntry(item, id, timestamp);
 		const name = item.title || ITEM_RESOLVER.loadItem(id)?.name || `Item ${id}`;
 
 		if (settings.pages.city.combineDuplicates) {
@@ -164,11 +175,94 @@ function resolveUserItems(decodedItems: (DecodedCityItem | InternalCityItem)[]):
 			if (duplicate) {
 				duplicate.count++;
 				duplicate.entries.push(entry);
-			} else items.push({ item: id, count: 1, name, entries: [entry] });
-		} else items.push({ item: id, count: 1, name, entries: [entry] });
+				duplicate.timestamp = Math.max(duplicate.timestamp, timestamp);
+			} else {
+				items.push({ item: id, count: 1, name, entries: [entry], timestamp, band: "" });
+			}
+		} else {
+			items.push({ item: id, count: 1, name, entries: [entry], timestamp, band: "" });
+		}
 	});
 
+	for (const item of items) item.band = getBandForTimestamp(item.timestamp);
+
 	return items;
+}
+
+function getItemTimestamp(item: DecodedCityItem | InternalCityItem): number {
+	if ("coordinates" in item) return item.timestamp;
+
+	return parseInt(item.ts, ENCODING_NUMERIC_SYSTEM);
+}
+
+const MILLISECONDS_PER_DAY = 86_400_000;
+
+// Relative time bands, newest first. City item timestamps are useful at UTC-day
+// granularity, so the minimum bucket is a single UTC day; wider bands span
+// multiple days. Bands are non-overlapping by age; every item lands in exactly one.
+const TIME_BANDS = [
+	{ key: "today", maxAgeDays: 0, label: "Today" },
+	{ key: "week", maxAgeDays: 7, label: "This week" },
+	{ key: "month", maxAgeDays: 30, label: "This month" },
+	{ key: "year", maxAgeDays: 365, label: "This year" },
+	{ key: "older", maxAgeDays: Number.POSITIVE_INFINITY, label: "More than a year ago" },
+] as const;
+
+const GROUP_PERIODS = [
+	{ key: "day", label: "Days" },
+	{ key: "week", label: "Weeks" },
+	{ key: "month", label: "Months" },
+	{ key: "year", label: "Years" },
+] as const;
+
+type GroupPeriod = (typeof GROUP_PERIODS)[number]["key"];
+
+function getUtcDayStart(milliseconds: number): number {
+	const date = new Date(milliseconds);
+	return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+function getUtcWeekStart(milliseconds: number): number {
+	const dayStart = getUtcDayStart(milliseconds);
+	const day = new Date(dayStart).getUTCDay();
+	return dayStart - ((day + 6) % 7) * MILLISECONDS_PER_DAY;
+}
+
+function getBandForTimestamp(timestampSeconds: number): string {
+	const ageDays = Math.floor((getUtcDayStart(Date.now()) - getUtcDayStart(timestampSeconds * 1000)) / MILLISECONDS_PER_DAY);
+	return TIME_BANDS.find((band) => ageDays <= band.maxAgeDays)?.key ?? "older";
+}
+
+function getBandOrder(): readonly string[] {
+	return TIME_BANDS.map((band) => band.key);
+}
+
+function formatBandLabel(bandKey: string): string {
+	return TIME_BANDS.find((band) => band.key === bandKey)?.label ?? bandKey;
+}
+
+function getGroupPeriod(): GroupPeriod {
+	const groupPeriod = settings.pages.city.groupByPeriodUnit;
+	return GROUP_PERIODS.some((period) => period.key === groupPeriod) ? (groupPeriod as GroupPeriod) : "day";
+}
+
+function getDateKey(milliseconds: number): string {
+	return new Date(milliseconds).toISOString().slice(0, 10);
+}
+
+function getGroupKey(timestampSeconds: number, groupPeriod = getGroupPeriod()): string {
+	const milliseconds = timestampSeconds * 1000;
+	const date = new Date(milliseconds);
+
+	if (groupPeriod === "day") return getDateKey(getUtcDayStart(milliseconds));
+	if (groupPeriod === "week") return getDateKey(getUtcWeekStart(milliseconds));
+	if (groupPeriod === "month") return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+
+	return String(date.getUTCFullYear());
+}
+
+function formatGroupLabel(groupKey: string, groupPeriod = getGroupPeriod()): string {
+	return groupPeriod === "week" ? `Week of ${groupKey}` : groupKey;
 }
 
 function getCityItemId(item: DecodedCityItem | InternalCityItem): number {
@@ -177,7 +271,7 @@ function getCityItemId(item: DecodedCityItem | InternalCityItem): number {
 	return parseInt(item.d, ENCODING_NUMERIC_SYSTEM);
 }
 
-function getCityItemEntry(item: DecodedCityItem | InternalCityItem, itemId: number): CityItemEntry {
+function getCityItemEntry(item: DecodedCityItem | InternalCityItem, itemId: number, timestamp: number): CityItemEntry {
 	let rowId: string, td: string, x: number, y: number;
 
 	if ("coordinates" in item) {
@@ -199,6 +293,7 @@ function getCityItemEntry(item: DecodedCityItem | InternalCityItem, itemId: numb
 		td,
 		x,
 		y,
+		timestamp,
 	};
 }
 
@@ -217,20 +312,43 @@ function setCityItems(items: CityItem[]) {
 	currentItems = items;
 
 	if (contentElement) populateContainer(contentElement, currentItems);
-	syncMapEntries(currentItems);
+	syncVisibleMapEntries();
 }
 
 function populateContainer(content: HTMLElement, items: CityItem[]) {
+	showControls(content, items);
 	if (ITEM_RESOLVER.hasFullItems()) showValue(content, items);
 	else content.querySelector(".tt-city-total")?.remove();
 	showItemList(content, items);
-	showSearchBox(content, items);
 }
 
-function showValue(content: HTMLElement, items: CityItem[]) {
-	content.querySelector(".tt-city-total")?.remove();
+function getFilteredItems(items: CityItem[]): CityItem[] {
+	const periodItems =
+		periodFilter === "all"
+			? items
+			: items.flatMap((item) => {
+					const entries = item.entries.filter((entry) => matchesPeriodFilter(getBandForTimestamp(entry.timestamp)));
+					if (!entries.length) return [];
 
-	const totalValue = items
+					const timestamp = Math.max(...entries.map((entry) => entry.timestamp));
+					return [{ ...item, count: entries.length, entries, timestamp, band: getBandForTimestamp(timestamp) }];
+				});
+
+	const query = searchQuery.trim().toLowerCase();
+	return query ? periodItems.filter((item) => item.name.toLowerCase().includes(query)) : periodItems;
+}
+
+function matchesPeriodFilter(itemBand: string): boolean {
+	if (periodFilter === "older") return itemBand === "older";
+
+	const selectedIndex = TIME_BANDS.findIndex((band) => band.key === periodFilter);
+	const itemIndex = TIME_BANDS.findIndex((band) => band.key === itemBand);
+
+	return selectedIndex >= 0 && itemIndex >= 0 && itemIndex <= selectedIndex;
+}
+
+function calculateItemValue(items: CityItem[]): { value: number; count: number } {
+	const value = items
 		.map(({ item, count }): (FullItem & { count: number }) | null => {
 			const fullItem = ITEM_RESOLVER.getFullItem(item);
 			return fullItem ? { ...fullItem, count } : null;
@@ -239,128 +357,310 @@ function showValue(content: HTMLElement, items: CityItem[]) {
 		.map(({ value: { market_price: value }, count }) => value * count)
 		.filter((value) => !!value)
 		.reduce((a, b) => a + b, 0);
-	const itemCount = items.map(({ count }) => count).reduce((a, b) => a + b, 0);
+	const count = items.reduce((total, item) => total + item.count, 0);
+
+	return { value, count };
+}
+
+function showValue(content: HTMLElement, items: CityItem[]) {
+	content.querySelector(".tt-city-total")?.remove();
+
+	if (!ITEM_RESOLVER.hasFullItems()) return;
+
+	const { value, count } = calculateItemValue(getFilteredItems(items));
 
 	content.appendChild(
 		elementBuilder({
 			type: "div",
-			class: "tt-city-total",
+			class: "tt-city-total hide-collapse",
 			children: [
-				elementBuilder({ type: "span", class: "tt-city-total-text", text: `Item Value (${itemCount}): ` }),
-				elementBuilder({ type: "span", class: "tt-city-total-value", text: formatNumber(totalValue, { currency: true }) }),
+				elementBuilder({ type: "span", class: "tt-city-total-text", text: `Item Value (${count}): ` }),
+				elementBuilder({ type: "span", class: "tt-city-total-value", text: formatNumber(value, { currency: true }) }),
 			],
 		}),
 	);
+}
+
+function refreshList() {
+	if (!contentElement) return;
+	showValue(contentElement, currentItems);
+	showItemList(contentElement, currentItems);
+	syncVisibleMapEntries();
+}
+
+function resetVisibleGroups() {
+	visibleGroupCount = GROUP_PAGE_SIZE;
+}
+
+function showControls(content: HTMLElement, items: CityItem[]) {
+	content.querySelector(".tt-city-controls")?.remove();
+
+	const groupByCheckbox = createCheckbox();
+	const groupBySelect = createSelect(GROUP_PERIODS.map((period) => ({ value: period.key, description: period.label })));
+	groupByCheckbox.setChecked(!!settings.pages.city.groupByPeriod);
+	groupBySelect.setSelected(getGroupPeriod());
+	groupBySelect.element.disabled = !groupByCheckbox.isChecked();
+	groupByCheckbox.onChange(() => {
+		const checked = groupByCheckbox.isChecked();
+		settings.pages.city.groupByPeriod = checked;
+		groupBySelect.element.disabled = !checked;
+		resetVisibleGroups();
+		void ttStorage.change({ settings: { pages: { city: { groupByPeriod: checked } } } });
+		refreshList();
+	});
+	groupBySelect.onChange(() => {
+		const groupByPeriodUnit = groupBySelect.getSelected();
+		settings.pages.city.groupByPeriodUnit = groupByPeriodUnit;
+		resetVisibleGroups();
+		void ttStorage.change({ settings: { pages: { city: { groupByPeriodUnit } } } });
+		refreshList();
+	});
+
+	const bandOrder = getBandOrder();
+	const presentBands = bandOrder.filter((band) => items.some((item) => item.entries.some((entry) => getBandForTimestamp(entry.timestamp) === band)));
+	const bandOptions = [
+		{ value: "all", description: "All" },
+		...presentBands.map((band) => ({ value: band, description: formatBandLabel(band) })),
+	];
+	const periodSelect = createSelect(bandOptions);
+	if (!periodSelect.setSelected(periodFilter)) {
+		periodSelect.setSelected("all");
+		periodFilter = "all";
+	}
+	periodSelect.onChange(() => {
+		periodFilter = periodSelect.getSelected();
+		resetVisibleGroups();
+		refreshList();
+	});
+
+	const searchInput = elementBuilder({
+		type: "input",
+		value: searchQuery,
+		attributes: { type: "text" },
+		events: {
+			input: (event) => {
+				if (!(event.currentTarget instanceof HTMLInputElement)) return;
+
+				searchQuery = event.currentTarget.value;
+				resetVisibleGroups();
+				refreshList();
+			},
+		},
+	});
+
+	content.appendChild(
+		elementBuilder({
+			type: "div",
+			class: "tt-city-controls hide-collapse",
+			children: [
+				elementBuilder({
+					type: "div",
+					class: "tt-city-group-filter",
+					children: [elementBuilder({ type: "span", class: "tt-city-control-label", text: "Group:" }), groupByCheckbox.element, groupBySelect.element],
+				}),
+				elementBuilder({
+					type: "label",
+					class: "tt-city-period-filter",
+					children: [elementBuilder({ type: "span", class: "tt-city-control-label", text: "Filter:" }), periodSelect.element],
+				}),
+				elementBuilder({
+					type: "label",
+					class: "tt-city-search-filter",
+					children: [elementBuilder({ type: "span", class: "tt-city-control-label", text: "Search:" }), searchInput],
+				}),
+			],
+		}),
+	);
+}
+
+function getGroupedItems(items: CityItem[]): { label: string; items: CityItem[] }[] {
+	const groupPeriod = getGroupPeriod();
+	const groups = new Map<string, CityItem[]>();
+
+	for (const item of items) {
+		for (const entry of item.entries) {
+			const key = getGroupKey(entry.timestamp, groupPeriod);
+			const groupItems = groups.get(key) ?? [];
+			groups.set(key, groupItems);
+
+			const duplicate = settings.pages.city.combineDuplicates ? groupItems.find((groupedItem) => groupedItem.item === item.item) : undefined;
+			if (duplicate) {
+				duplicate.count++;
+				duplicate.entries.push(entry);
+				duplicate.timestamp = Math.max(duplicate.timestamp, entry.timestamp);
+				duplicate.band = getBandForTimestamp(duplicate.timestamp);
+			} else {
+				groupItems.push({ ...item, count: 1, entries: [entry], timestamp: entry.timestamp, band: getBandForTimestamp(entry.timestamp) });
+			}
+		}
+	}
+
+	return [...groups.entries()]
+		.sort(([a], [b]) => b.localeCompare(a))
+		.map(([key, groupItems]) => ({ label: formatGroupLabel(key, groupPeriod), items: groupItems }));
 }
 
 function showItemList(content: HTMLElement, items: CityItem[]) {
 	content.querySelector(".tt-city-items")?.remove();
 
 	const listElement = elementBuilder({ type: "div", class: "tt-city-items hide-collapse" });
+	const filtered = getFilteredItems(items);
 
-	const type = "text";
-	switch (type) {
-		case "text":
-			generateText();
-			break;
-	}
+	if (settings.pages.city.groupByPeriod) {
+		const groups = getGroupedItems(filtered);
+		const visibleGroups = groups.slice(0, visibleGroupCount);
+		if (!groups.length) {
+			listElement.appendChild(elementBuilder({ type: "p", text: "There are no items in the city." }));
+		} else {
+			for (const group of visibleGroups) {
+				const { value, count } = calculateItemValue(group.items);
+				listElement.appendChild(
+					elementBuilder({
+						type: "div",
+						class: "tt-city-period-group",
+						children: [
+							elementBuilder({
+								type: "div",
+								class: "tt-city-period-header",
+								children: [
+									elementBuilder({ type: "span", class: "tt-city-period-name", text: group.label }),
+									elementBuilder({ type: "span", class: "tt-city-period-count", text: `(${count})` }),
+									elementBuilder({
+										type: "span",
+										class: "tt-city-period-value",
+										text: ITEM_RESOLVER.hasFullItems() ? formatNumber(value, { currency: true }) : "",
+									}),
+								],
+							}),
+						],
+					}),
+				);
+				appendItemsParagraph(listElement, group.items, false);
+			}
+			appendGroupPaginationControls(listElement, groups.length, visibleGroups.length);
+		}
+	} else appendItemsParagraph(listElement, filtered, true);
 
 	content.appendChild(listElement);
-
-	function generateText() {
-		let element: HTMLElement;
-		if (items.length > 0) {
-			const totalCount = items.map(({ count }) => count).reduce((a, b) => a + b, 0);
-			element = elementBuilder({
-				type: "p",
-				children: [
-					"There",
-					totalCount === 1 ? " is " : " are ",
-					elementBuilder({ type: "strong", text: totalCount }),
-					totalCount === 1 ? " item " : " items ",
-					"in the city: ",
-				],
-			});
-
-			const _items = [...items];
-			if (items.length === 1) {
-				element.appendChild(createItemElement(_items[0]));
-			} else {
-				const last = _items.splice(-1)[0];
-
-				for (const item of _items) {
-					element.appendChild(createItemElement(item));
-					element.appendChild(document.createTextNode(", "));
-				}
-				element.lastChild.remove();
-
-				element.appendChild(document.createTextNode(" and "));
-				element.appendChild(createItemElement(last));
-			}
-
-			element.appendChild(document.createTextNode("."));
-		} else {
-			element = elementBuilder({ type: "p", text: "There are no items in the city." });
-		}
-		listElement.appendChild(element);
-
-		function createItemElement({ item, name, count, entries }: CityItem) {
-			let text: string;
-			if (count > 1) {
-				text = `${count}x ${name}`;
-			} else text = name;
-
-			return elementBuilder({
-				type: "span",
-				text,
-				class: "list-item",
-				dataset: { id: item },
-				events: {
-					mouseenter() {
-						highlightItem(item, true);
-					},
-					mouseleave() {
-						highlightItem(item, false);
-					},
-					click(event) {
-						if (!event.isTrusted) return;
-
-						collectEntry(entries[0], item, name).catch(console.error);
-					},
-				},
-			});
-		}
-	}
 }
 
-function showSearchBox(content: HTMLElement, items: CityItem[]) {
-	content.querySelector(".tt-city-search")?.remove();
+function appendGroupPaginationControls(parent: HTMLElement, totalGroups: number, visibleGroups: number) {
+	if (totalGroups <= GROUP_PAGE_SIZE) return;
 
-	const searchBox = elementBuilder({
-		type: "label",
-		class: "tt-city-search",
-		text: "Search:",
-		children: [
+	const hasMore = visibleGroups < totalGroups;
+	const controls = elementBuilder({
+		type: "div",
+		class: "tt-city-group-pagination",
+		children: [elementBuilder({ type: "span", text: `Showing ${visibleGroups} of ${totalGroups} groups` })],
+	});
+
+	if (hasMore) {
+		controls.appendChild(
 			elementBuilder({
-				type: "input",
-				attributes: { type: "text" },
+				type: "button",
+				class: "tt-button-link tt-city-group-pagination-button",
+				text: "Show more",
+				attributes: { type: "button" },
 				events: {
-					input: (event) => {
-						if (!(event.currentTarget instanceof HTMLInputElement)) return;
-
-						const query = event.currentTarget.value.toLowerCase();
-						clearSearchHighlights();
-						if (!query.length) return;
-
-						const matchedItemIds = items.filter((item) => item.name.toLowerCase().includes(query)).map((item) => item.item);
-						for (const itemId of matchedItemIds) highlightItem(itemId, true, "search-hover");
+					click: () => {
+						visibleGroupCount = Math.min(visibleGroupCount + GROUP_PAGE_SIZE, totalGroups);
+						refreshList();
 					},
 				},
 			}),
-		],
-	});
+		);
+		controls.appendChild(
+			elementBuilder({
+				type: "button",
+				class: "tt-button-link tt-city-group-pagination-button",
+				text: "Show all",
+				attributes: { type: "button" },
+				events: {
+					click: () => {
+						visibleGroupCount = totalGroups;
+						refreshList();
+					},
+				},
+			}),
+		);
+	}
 
-	content.appendChild(searchBox);
+	if (visibleGroups > GROUP_PAGE_SIZE) {
+		controls.appendChild(
+			elementBuilder({
+				type: "button",
+				class: "tt-button-link tt-city-group-pagination-button",
+				text: "Show fewer",
+				attributes: { type: "button" },
+				events: {
+					click: () => {
+						resetVisibleGroups();
+						refreshList();
+					},
+				},
+			}),
+		);
+	}
+
+	parent.appendChild(controls);
+}
+
+function appendItemsParagraph(parent: HTMLElement, items: CityItem[], withPreamble: boolean) {
+	const totalCount = items.reduce((total, item) => total + item.count, 0);
+	if (!totalCount) {
+		if (withPreamble) parent.appendChild(elementBuilder({ type: "p", text: "There are no items in the city." }));
+		return;
+	}
+
+	const children: (string | HTMLElement)[] = [];
+	if (withPreamble) {
+		children.push("There", totalCount === 1 ? " is " : " are ", elementBuilder({ type: "strong", text: String(totalCount) }), totalCount === 1 ? " item " : " items ", "in the city: ");
+	}
+
+	const paragraph = elementBuilder({ type: "p", children });
+
+	if (items.length === 1) {
+		paragraph.appendChild(createItemSpan(items[0]));
+	} else {
+		const list = [...items];
+		const last = list.splice(-1)[0];
+
+		for (const item of list) {
+			paragraph.appendChild(createItemSpan(item));
+			paragraph.appendChild(document.createTextNode(", "));
+		}
+		if (paragraph.lastChild) paragraph.lastChild.remove();
+
+		paragraph.appendChild(document.createTextNode(" and "));
+		paragraph.appendChild(createItemSpan(last));
+	}
+
+	paragraph.appendChild(document.createTextNode("."));
+	parent.appendChild(paragraph);
+}
+
+function createItemSpan({ item, name, count, entries }: CityItem) {
+	const text = count > 1 ? `${count}x ${name}` : name;
+
+	return elementBuilder({
+		type: "span",
+		text,
+		class: "list-item",
+		dataset: { id: item },
+		events: {
+			mouseenter() {
+				highlightItem(item, true);
+			},
+			mouseleave() {
+				highlightItem(item, false);
+			},
+			click(event) {
+				if (!event.isTrusted) return;
+
+				collectEntry(entries[0], item, name).catch(console.error);
+			},
+		},
+	});
 }
 
 async function collectEntry(entry: CityItemEntry, item: number, name: string) {
@@ -429,7 +729,9 @@ function removeEntryFromItems(entry: CityItemEntry): CityItem[] {
 		}
 
 		if (item.entries.length > 1) {
-			nextItems.push({ ...item, count: item.count - 1, entries: item.entries.filter((_, index) => index !== entryIndex) });
+			const entries = item.entries.filter((_, index) => index !== entryIndex);
+			const timestamp = Math.max(...entries.map((entry) => entry.timestamp));
+			nextItems.push({ ...item, count: item.count - 1, entries, timestamp, band: getBandForTimestamp(timestamp) });
 		}
 	}
 
@@ -456,6 +758,10 @@ async function collectItem(td: string): Promise<void> {
 
 	const result = await fetchData<unknown>("torn_direct", { action: "city.php", method: "POST", body });
 	if (!isSuccessfulPickupResponse(result, typeof result === "string" ? result : undefined)) throw new Error("City item pickup failed.");
+}
+
+function syncVisibleMapEntries() {
+	syncMapEntries(getFilteredItems(currentItems));
 }
 
 function syncMapEntries(items: CityItem[]) {
@@ -485,11 +791,7 @@ function highlightItem(itemId: number, state: boolean, className = "force-hover"
 }
 
 function clearForcedHighlights() {
-	for (const item of findAllElements(".city-item.force-hover, .city-item.search-hover")) item.classList.remove("force-hover", "search-hover");
-}
-
-function clearSearchHighlights() {
-	for (const item of findAllElements(".city-item.search-hover")) item.classList.remove("search-hover");
+	for (const item of findAllElements(".city-item.force-hover")) item.classList.remove("force-hover");
 }
 
 function parseNumericDatasetValue(value: string | undefined): number | undefined {
@@ -549,6 +851,9 @@ function removeHighlight() {
 	removeContainer("City Items");
 	contentElement = null;
 	currentItems = [];
+	periodFilter = "all";
+	searchQuery = "";
+	resetVisibleGroups();
 	collectingEntries.clear();
 	clearForcedHighlights();
 	dispatchMapEvent(CITY_ITEMS_MAP_EVENTS.CLEAR);

--- a/src/common/features/city-items/city-items.ts
+++ b/src/common/features/city-items/city-items.ts
@@ -722,6 +722,7 @@ function handleCollectedEntry(entry: CityItemEntry, item: number, name: string) 
 	if (!findEntry(entry.td, entry.entryId)) return;
 
 	setCityItems(removeEntryFromItems(entry));
+	clearForcedHighlights();
 
 	let text: string;
 	if (ITEM_RESOLVER.hasFullItems()) {

--- a/src/common/features/city-items/city-items.ts
+++ b/src/common/features/city-items/city-items.ts
@@ -6,7 +6,7 @@ import { displayAlert } from "@common/utils/functions/alerts";
 import { fetchData } from "@common/utils/functions/api-fetcher";
 import { createContainer, findContainer, removeContainer } from "@common/utils/functions/containers";
 import { elementBuilder, findAllElements } from "@common/utils/functions/dom";
-import { formatNumber } from "@common/utils/functions/formatting";
+import { formatDate, formatNumber, toMultipleDigits } from "@common/utils/functions/formatting";
 import { addXHRListener } from "@common/utils/functions/listeners";
 import { requireElement } from "@common/utils/functions/requires";
 import { createCheckbox } from "@common/utils/elements/checkbox/checkbox";
@@ -246,23 +246,46 @@ function getGroupPeriod(): GroupPeriod {
 	return GROUP_PERIODS.some((period) => period.key === groupPeriod) ? (groupPeriod as GroupPeriod) : "day";
 }
 
-function getDateKey(milliseconds: number): string {
-	return new Date(milliseconds).toISOString().slice(0, 10);
+function getGroupKey(timestampSeconds: number, groupPeriod = getGroupPeriod()): string {
+	return getGroupStart(timestampSeconds, groupPeriod).toString();
 }
 
-function getGroupKey(timestampSeconds: number, groupPeriod = getGroupPeriod()): string {
+function getGroupStart(timestampSeconds: number, groupPeriod: GroupPeriod): number {
 	const milliseconds = timestampSeconds * 1000;
 	const date = new Date(milliseconds);
 
-	if (groupPeriod === "day") return getDateKey(getUtcDayStart(milliseconds));
-	if (groupPeriod === "week") return getDateKey(getUtcWeekStart(milliseconds));
-	if (groupPeriod === "month") return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+	if (groupPeriod === "day") return getUtcDayStart(milliseconds);
+	if (groupPeriod === "week") return getUtcWeekStart(milliseconds);
+	if (groupPeriod === "month") return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1);
 
-	return String(date.getUTCFullYear());
+	return Date.UTC(date.getUTCFullYear(), 0, 1);
 }
 
 function formatGroupLabel(groupKey: string, groupPeriod = getGroupPeriod()): string {
-	return groupPeriod === "week" ? `Week of ${groupKey}` : groupKey;
+	const milliseconds = Number(groupKey);
+	if (!Number.isFinite(milliseconds)) return groupKey;
+
+	if (groupPeriod === "month") return formatMonthGroupLabel(milliseconds);
+	if (groupPeriod === "year") return String(new Date(milliseconds).getUTCFullYear());
+
+	const date = formatUtcDate(milliseconds);
+	return groupPeriod === "week" ? `Week of ${date}` : date;
+}
+
+function formatUtcDate(milliseconds: number): string {
+	const date = new Date(milliseconds);
+	const formattingDate = settings.formatting.tct ? date : new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+	return formatDate(formattingDate, { showYear: true });
+}
+
+function formatMonthGroupLabel(milliseconds: number): string {
+	const date = new Date(milliseconds);
+	const month = toMultipleDigits(date.getUTCMonth() + 1);
+	const year = date.getUTCFullYear();
+
+	if (settings.formatting.date === "us") return `${month}/${year}`;
+	if (settings.formatting.date === "eu") return `${month}.${year}`;
+	return `${year}-${month}`;
 }
 
 function getCityItemId(item: DecodedCityItem | InternalCityItem): number {
@@ -496,7 +519,7 @@ function getGroupedItems(items: CityItem[]): { label: string; items: CityItem[] 
 	}
 
 	return [...groups.entries()]
-		.sort(([a], [b]) => b.localeCompare(a))
+		.sort(([a], [b]) => Number(b) - Number(a))
 		.map(([key, groupItems]) => ({ label: formatGroupLabel(key, groupPeriod), items: groupItems }));
 }
 

--- a/src/common/features/city-items/city-items.ts
+++ b/src/common/features/city-items/city-items.ts
@@ -5,96 +5,237 @@ import { settings } from "@common/utils/data/database";
 import { displayAlert } from "@common/utils/functions/alerts";
 import { fetchData } from "@common/utils/functions/api-fetcher";
 import { createContainer, findContainer, removeContainer } from "@common/utils/functions/containers";
-import { elementBuilder } from "@common/utils/functions/dom";
+import { elementBuilder, findAllElements } from "@common/utils/functions/dom";
 import { formatNumber } from "@common/utils/functions/formatting";
 import { addXHRListener } from "@common/utils/functions/listeners";
 import { requireElement } from "@common/utils/functions/requires";
 import { getPageStatus } from "@common/utils/functions/torn";
 import type { FullItem } from "@common/utils/torn-api/items.types";
-import { Feature } from "@features/feature";
+import { ExecutionTiming, Feature } from "@features/feature";
+import { CITY_ITEMS_MAP_EVENTS, type CityItemsMapEntry } from "./city-items-map";
 
 const ENCODING_NUMERIC_SYSTEM = 36;
+
+type CityItemEntry = CityItemsMapEntry;
 
 interface CityItem {
 	item: number;
 	count: number;
 	name: string;
-	entries: { id: string; td: string }[];
+	entries: CityItemEntry[];
 }
 
+let contentElement: HTMLElement | null = null;
+let currentItems: CityItem[] = [];
+const collectingEntries = new Set<string>();
+
 function initialise() {
+	SCRIPT_INJECTOR.injectCityItemsMap?.();
+
 	addXHRListener(({ detail: { page, xhr, json } }) => {
 		if (!FEATURE_MANAGER.isEnabled(CityItemsFeature)) return;
 
 		if (isMapData(page, xhr, json)) {
-			const items = resolveUserItems(JSON.parse(atob(json.territoryUserItems)));
+			const items = resolveUserItems(decodeTerritoryUserItems(json.territoryUserItems));
 
 			showCityItemsContainer(items).catch(console.error);
+			return;
 		}
+
+		const pickupTd = getPickupTd(page, xhr.requestBody);
+		if (pickupTd && isSuccessfulPickupResponse(json, xhr.responseText)) handleCollectedTd(pickupTd);
 	});
+
+	document.addEventListener("click", handleMapOverlayClick, true);
+	window.addEventListener(CITY_ITEMS_MAP_EVENTS.MODEL_ITEMS, handleModelItems);
 }
 
 function triggerFallback() {
 	if (findContainer("City Items")) return;
 
-	const model = SCRIPT_INJECTOR.getWindow().torn?.model?.get?.();
-	if (!model) return;
+	const userItems = getPageModelItems();
+	if (userItems?.length) {
+		const items = resolveUserItems(userItems);
+		showCityItemsContainer(items).catch(console.error);
+		return;
+	}
 
-	const userItems = model.territoryUserItems;
-	if (!userItems) return;
+	SCRIPT_INJECTOR.injectCityItemsMap?.();
+	window.setTimeout(() => dispatchMapEvent(CITY_ITEMS_MAP_EVENTS.REQUEST_MODEL_ITEMS), 100);
+}
 
-	const items = resolveUserItems(userItems);
+function handleModelItems(event: Event) {
+	const detail = parseEventDetail<{ items?: unknown }>(event);
+	if (!FEATURE_MANAGER.isEnabled(CityItemsFeature) || findContainer("City Items") || !detail) return;
 
+	const userItems = detail.items;
+	if (!Array.isArray(userItems)) return;
+
+	const internalItems = userItems.filter(isInternalCityItem);
+	if (!internalItems.length) return;
+
+	const items = resolveUserItems(internalItems);
 	showCityItemsContainer(items).catch(console.error);
+}
+
+function getPageModelItems(): InternalCityItem[] | null {
+	const model = SCRIPT_INJECTOR.getWindow().torn?.model;
+	if (!model || typeof model.get !== "function") return null;
+
+	try {
+		const fullModel = model.get();
+		if (Array.isArray(fullModel?.territoryUserItems)) return fullModel.territoryUserItems;
+	} catch {}
+
+	try {
+		const userItems = model.get("territoryUserItems");
+		if (Array.isArray(userItems)) return userItems;
+	} catch {}
+
+	return null;
+}
+
+function isInternalCityItem(value: unknown): value is InternalCityItem {
+	return (
+		isRecord(value) &&
+		Array.isArray(value.coordinates) &&
+		value.coordinates.length >= 2 &&
+		typeof value.coordinates[0] === "number" &&
+		typeof value.coordinates[1] === "number" &&
+		typeof value.item_id === "number" &&
+		typeof value.row_id === "number" &&
+		typeof value.timestamp === "number" &&
+		typeof value.title === "string"
+	);
+}
+
+function parseEventDetail<T>(event: Event): T | null {
+	if (!isCustomEvent<unknown>(event)) return null;
+
+	if (typeof event.detail === "string") {
+		try {
+			return JSON.parse(event.detail) as T;
+		} catch {
+			return null;
+		}
+	}
+
+	return event.detail as T;
+}
+
+function isCustomEvent<T>(event: Event): event is CustomEvent<T> {
+	return "detail" in event;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function hasGetMethod(value: unknown): value is { get(param: string): unknown } {
+	return isRecord(value) && typeof value.get === "function";
+}
+
+function decodeTerritoryUserItems(encodedItems: string): DecodedCityItem[] {
+	const binary = atob(encodedItems);
+	let decoded = binary;
+
+	try {
+		const bytes = new Uint8Array(binary.length);
+		for (let index = 0; index < binary.length; index++) bytes[index] = binary.charCodeAt(index);
+		decoded = new TextDecoder("utf-8").decode(bytes);
+	} catch {}
+
+	return JSON.parse(decoded);
 }
 
 function resolveUserItems(decodedItems: (DecodedCityItem | InternalCityItem)[]): CityItem[] {
 	const items: CityItem[] = [];
 
 	decodedItems.forEach((item) => {
-		const id = ITEM_RESOLVER.findItem((x) => x.name === item.title)?.id ?? -1;
+		const id = getCityItemId(item);
+		if (!Number.isFinite(id)) return;
 
-		let internalId: string, td: string;
-		if ("coordinates" in item) {
-			internalId = item.row_id.toString(ENCODING_NUMERIC_SYSTEM);
-			td = btoa([item.coordinates[0], item.coordinates[1], item.row_id, item.timestamp].map((x) => x.toString(ENCODING_NUMERIC_SYSTEM)).join("O"));
-		} else {
-			internalId = item.id;
-			td = btoa([item.c.x, item.c.y, item.id, item.ts].join("O"));
-		}
+		const entry = getCityItemEntry(item, id);
+		const name = item.title || ITEM_RESOLVER.loadItem(id)?.name || `Item ${id}`;
 
 		if (settings.pages.city.combineDuplicates) {
 			const duplicate = items.find((item) => item.item === id);
 
 			if (duplicate) {
 				duplicate.count++;
-				duplicate.entries.push({ id: internalId, td });
-			} else items.push({ item: id, count: 1, name: item.title, entries: [{ id: internalId, td }] });
-		} else items.push({ item: id, count: 1, name: item.title, entries: [{ id: internalId, td }] });
+				duplicate.entries.push(entry);
+			} else items.push({ item: id, count: 1, name, entries: [entry] });
+		} else items.push({ item: id, count: 1, name, entries: [entry] });
 	});
 
 	return items;
 }
 
+function getCityItemId(item: DecodedCityItem | InternalCityItem): number {
+	if ("coordinates" in item) return item.item_id;
+
+	return parseInt(item.d, ENCODING_NUMERIC_SYSTEM);
+}
+
+function getCityItemEntry(item: DecodedCityItem | InternalCityItem, itemId: number): CityItemEntry {
+	let rowId: string, td: string, x: number, y: number;
+
+	if ("coordinates" in item) {
+		rowId = item.row_id.toString(ENCODING_NUMERIC_SYSTEM);
+		td = btoa([item.coordinates[0], item.coordinates[1], item.row_id, item.timestamp].map((value) => value.toString(ENCODING_NUMERIC_SYSTEM)).join("O"));
+		x = item.coordinates[0];
+		y = item.coordinates[1];
+	} else {
+		rowId = item.id;
+		td = btoa([item.c.x, item.c.y, item.id, item.ts].join("O"));
+		x = parseInt(item.c.x, ENCODING_NUMERIC_SYSTEM);
+		y = parseInt(item.c.y, ENCODING_NUMERIC_SYSTEM);
+	}
+
+	return {
+		entryId: rowId,
+		itemId,
+		name: item.title,
+		td,
+		x,
+		y,
+	};
+}
+
 async function showCityItemsContainer(items: CityItem[]) {
 	await requireElement("#map .leaflet-zoom-animated");
 
-	const { content } = createContainer("City Items", { class: "mt10", alwaysContent: true, nextElement: document.querySelector("#tab-menu") });
+	if (!contentElement || !document.contains(contentElement)) {
+		const { content } = createContainer("City Items", { class: "mt10", alwaysContent: true, nextElement: document.querySelector("#tab-menu") });
+		contentElement = content;
+	}
 
-	populateContainer(content, items);
+	setCityItems(items);
+}
+
+function setCityItems(items: CityItem[]) {
+	currentItems = items;
+
+	if (contentElement) populateContainer(contentElement, currentItems);
+	syncMapEntries(currentItems);
 }
 
 function populateContainer(content: HTMLElement, items: CityItem[]) {
 	if (ITEM_RESOLVER.hasFullItems()) showValue(content, items);
+	else content.querySelector(".tt-city-total")?.remove();
 	showItemList(content, items);
+	showSearchBox(content, items);
 }
 
 function showValue(content: HTMLElement, items: CityItem[]) {
 	content.querySelector(".tt-city-total")?.remove();
 
 	const totalValue = items
-		.map(({ item, count }): FullItem & { count: number } => ({ ...ITEM_RESOLVER.getFullItem(item), count }))
-		.filter((item) => !!item)
+		.map(({ item, count }): (FullItem & { count: number }) | null => {
+			const fullItem = ITEM_RESOLVER.getFullItem(item);
+			return fullItem ? { ...fullItem, count } : null;
+		})
+		.filter((item): item is FullItem & { count: number } => !!item)
 		.map(({ value: { market_price: value }, count }) => value * count)
 		.filter((value) => !!value)
 		.reduce((a, b) => a + b, 0);
@@ -173,26 +314,18 @@ function showItemList(content: HTMLElement, items: CityItem[]) {
 				type: "span",
 				text,
 				class: "list-item",
+				dataset: { id: item },
 				events: {
-					click() {
-						const entry = entries[0];
+					mouseenter() {
+						highlightItem(item, true);
+					},
+					mouseleave() {
+						highlightItem(item, false);
+					},
+					click(event) {
+						if (!event.isTrusted) return;
 
-						collectItem(entry.td).then(() => {
-							const newItems = [...items.filter((a) => a.item !== item)];
-							if (entries.length > 1) newItems.push({ item, name, count: count - 1, entries: entries.slice(1) });
-
-							populateContainer(content, newItems);
-
-							let text: string;
-							if (ITEM_RESOLVER.hasFullItems()) {
-								const value = ITEM_RESOLVER.getFullItem(item)?.value.market_price ?? 0;
-								text = `Collected ${name} with a value of ${formatNumber(value, { currency: true })}.`;
-							} else {
-								text = `Collected ${name}.`;
-							}
-
-							displayAlert({ title: "Collected Item", text, type: "success" });
-						});
+						collectEntry(entries[0], item, name).catch(console.error);
 					},
 				},
 			});
@@ -200,21 +333,231 @@ function showItemList(content: HTMLElement, items: CityItem[]) {
 	}
 }
 
+function showSearchBox(content: HTMLElement, items: CityItem[]) {
+	content.querySelector(".tt-city-search")?.remove();
+
+	const searchBox = elementBuilder({
+		type: "label",
+		class: "tt-city-search",
+		text: "Search:",
+		children: [
+			elementBuilder({
+				type: "input",
+				attributes: { type: "text" },
+				events: {
+					input: (event) => {
+						if (!(event.currentTarget instanceof HTMLInputElement)) return;
+
+						const query = event.currentTarget.value.toLowerCase();
+						clearSearchHighlights();
+						if (!query.length) return;
+
+						const matchedItemIds = items.filter((item) => item.name.toLowerCase().includes(query)).map((item) => item.item);
+						for (const itemId of matchedItemIds) highlightItem(itemId, true, "search-hover");
+					},
+				},
+			}),
+		],
+	});
+
+	content.appendChild(searchBox);
+}
+
+async function collectEntry(entry: CityItemEntry, item: number, name: string) {
+	if (collectingEntries.has(entry.entryId)) return;
+
+	collectingEntries.add(entry.entryId);
+	try {
+		await collectItem(entry.td);
+		handleCollectedEntry(entry, item, name);
+	} finally {
+		collectingEntries.delete(entry.entryId);
+	}
+}
+
+function handleMapOverlayClick(event: MouseEvent) {
+	if (!event.isTrusted) return;
+	if (!(event.target instanceof Element)) return;
+
+	const overlay = event.target.closest<HTMLElement>(".tt-city-item-overlay.city-item");
+	if (!overlay) return;
+
+	const entry = findEntry(overlay.dataset.td, overlay.dataset.entryId, parseNumericDatasetValue(overlay.dataset.itemId));
+	if (!entry) return;
+
+	event.preventDefault();
+	event.stopPropagation();
+	if (typeof event.stopImmediatePropagation === "function") event.stopImmediatePropagation();
+
+	const item = findCityItemForEntry(entry);
+	collectEntry(entry, entry.itemId, item?.name ?? entry.name).catch(console.error);
+}
+
+function handleCollectedTd(td: string) {
+	const entry = findEntry(td);
+	if (!entry) return;
+
+	const item = entry.itemId;
+	const name = findCityItemForEntry(entry)?.name ?? entry.name;
+	handleCollectedEntry(entry, item, name);
+}
+
+function handleCollectedEntry(entry: CityItemEntry, item: number, name: string) {
+	if (!findEntry(entry.td, entry.entryId)) return;
+
+	setCityItems(removeEntryFromItems(entry));
+
+	let text: string;
+	if (ITEM_RESOLVER.hasFullItems()) {
+		const value = ITEM_RESOLVER.getFullItem(item)?.value.market_price ?? 0;
+		text = `Collected ${name} with a value of ${formatNumber(value, { currency: true })}.`;
+	} else {
+		text = `Collected ${name}.`;
+	}
+
+	displayAlert({ title: "Collected Item", text, type: "success" });
+}
+
+function removeEntryFromItems(entry: CityItemEntry): CityItem[] {
+	const nextItems: CityItem[] = [];
+
+	for (const item of currentItems) {
+		const entryIndex = item.entries.findIndex((existing) => existing.td === entry.td || existing.entryId === entry.entryId);
+		if (entryIndex === -1) {
+			nextItems.push(item);
+			continue;
+		}
+
+		if (item.entries.length > 1) {
+			nextItems.push({ ...item, count: item.count - 1, entries: item.entries.filter((_, index) => index !== entryIndex) });
+		}
+	}
+
+	return nextItems;
+}
+
+function findEntry(td?: string, entryId?: string, itemId?: number): CityItemEntry | null {
+	for (const item of currentItems) {
+		const entry = item.entries.find((entry) => (td && entry.td === td) || (entryId && entry.entryId === entryId) || (itemId && entry.itemId === itemId));
+		if (entry) return entry;
+	}
+
+	return null;
+}
+
+function findCityItemForEntry(entry: CityItemEntry): CityItem | null {
+	return currentItems.find((item) => item.entries.some((existing) => existing.td === entry.td || existing.entryId === entry.entryId)) ?? null;
+}
+
 async function collectItem(td: string): Promise<void> {
 	const body = new URLSearchParams();
 	body.set("step", "uif");
 	body.set("td", td);
 
-	await fetchData("torn_direct", { action: "city.php", method: "POST", body });
+	const result = await fetchData<unknown>("torn_direct", { action: "city.php", method: "POST", body });
+	if (!isSuccessfulPickupResponse(result, typeof result === "string" ? result : undefined)) throw new Error("City item pickup failed.");
+}
+
+function syncMapEntries(items: CityItem[]) {
+	dispatchMapEvent(CITY_ITEMS_MAP_EVENTS.SET_ITEMS, {
+		entries: items.flatMap(({ entries }) => entries.map(({ entryId, itemId, name, td, x, y }) => ({ entryId, itemId, name, td, x, y }))),
+	});
+}
+
+function dispatchMapEvent(name: (typeof CITY_ITEMS_MAP_EVENTS)[keyof typeof CITY_ITEMS_MAP_EVENTS], detail?: unknown) {
+	SCRIPT_INJECTOR.getWindow().dispatchEvent(new CustomEvent(name, { detail: serializeEventDetail(detail) }));
+}
+
+function serializeEventDetail(detail: unknown): string | undefined {
+	if (detail === undefined) return undefined;
+
+	try {
+		return JSON.stringify(detail);
+	} catch {
+		return undefined;
+	}
+}
+
+function highlightItem(itemId: number, state: boolean, className = "force-hover") {
+	for (const item of findAllElements<HTMLElement>(`.city-item[data-id="${itemId}"]`)) {
+		item.classList.toggle(className, state);
+	}
+}
+
+function clearForcedHighlights() {
+	for (const item of findAllElements(".city-item.force-hover, .city-item.search-hover")) item.classList.remove("force-hover", "search-hover");
+}
+
+function clearSearchHighlights() {
+	for (const item of findAllElements(".city-item.search-hover")) item.classList.remove("search-hover");
+}
+
+function parseNumericDatasetValue(value: string | undefined): number | undefined {
+	if (value === undefined) return undefined;
+
+	const parsed = parseInt(value);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function getPickupTd(page: string, body: unknown): string | null {
+	if (page !== "city") return null;
+	if (getBodyParam(body, "step") !== "uif") return null;
+
+	return getBodyParam(body, "td");
+}
+
+function getBodyParam(body: unknown, param: string): string | null {
+	if (!body) return null;
+
+	if (typeof body === "string") return new URLSearchParams(body).get(param);
+
+	if (body instanceof URLSearchParams) return body.get(param);
+
+	if (hasGetMethod(body)) {
+		const value = body.get(param);
+		return value == null ? null : value.toString();
+	}
+
+	if (isRecord(body) && param in body) {
+		const value = body[param];
+		return value == null ? null : value.toString();
+	}
+
+	return null;
+}
+
+function isSuccessfulPickupResponse(json: unknown, text?: string): boolean {
+	if (isRecord(json)) {
+		if ("success" in json) return json.success === true || json.success === "true" || json.success === 1;
+		if ("error" in json && json.error) return false;
+	}
+
+	if (typeof text === "string") {
+		if (!text.trim()) return true;
+
+		try {
+			return isSuccessfulPickupResponse(JSON.parse(text));
+		} catch {
+			return false;
+		}
+	}
+
+	return false;
 }
 
 function removeHighlight() {
 	removeContainer("City Items");
+	contentElement = null;
+	currentItems = [];
+	collectingEntries.clear();
+	clearForcedHighlights();
+	dispatchMapEvent(CITY_ITEMS_MAP_EVENTS.CLEAR);
+	document.removeEventListener("click", handleMapOverlayClick, true);
 }
 
 export default class CityItemsFeature extends Feature {
 	constructor() {
-		super("City Items", "city");
+		super("City Items", "city", ExecutionTiming.IMMEDIATELY);
 	}
 
 	precondition() {
@@ -235,6 +578,10 @@ export default class CityItemsFeature extends Feature {
 
 	cleanup() {
 		removeHighlight();
+	}
+
+	requiresScreenInformation() {
+		return false;
 	}
 
 	storageKeys() {

--- a/src/common/features/city-items/city-items.ts
+++ b/src/common/features/city-items/city-items.ts
@@ -9,6 +9,7 @@ import { elementBuilder, findAllElements } from "@common/utils/functions/dom";
 import { formatDate, formatNumber } from "@common/utils/functions/formatting";
 import { addXHRListener } from "@common/utils/functions/listeners";
 import { requireElement } from "@common/utils/functions/requires";
+import { MONTHS } from "@common/utils/functions/utilities";
 import { createCheckbox } from "@common/utils/elements/checkbox/checkbox";
 import { createSelect } from "@common/utils/elements/select/select";
 import { getPageStatus } from "@common/utils/functions/torn";
@@ -266,7 +267,7 @@ function formatGroupLabel(groupKey: string, groupPeriod = getGroupPeriod()): str
 	if (!Number.isFinite(milliseconds)) return groupKey;
 
 	const date = new Date(milliseconds);
-	if (groupPeriod === "month") return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+	if (groupPeriod === "month") return `${MONTHS[date.getUTCMonth()]} ${date.getUTCFullYear()}`;
 	if (groupPeriod === "year") return String(date.getUTCFullYear());
 
 	const formattedDate = formatDate({ milliseconds }, { showYear: true });

--- a/src/common/features/city-items/city-items.ts
+++ b/src/common/features/city-items/city-items.ts
@@ -801,7 +801,7 @@ function serializeEventDetail(detail: unknown): string | undefined {
 }
 
 function highlightItem(itemId: number, state: boolean, className = "force-hover") {
-	for (const item of findAllElements<HTMLElement>(`.city-item[data-id="${itemId}"]`)) {
+	for (const item of findAllElements(`.city-item[data-id="${itemId}"]`)) {
 		item.classList.toggle(className, state);
 	}
 }

--- a/src/common/features/city-items/city-items.ts
+++ b/src/common/features/city-items/city-items.ts
@@ -6,7 +6,7 @@ import { displayAlert } from "@common/utils/functions/alerts";
 import { fetchData } from "@common/utils/functions/api-fetcher";
 import { createContainer, findContainer, removeContainer } from "@common/utils/functions/containers";
 import { elementBuilder, findAllElements } from "@common/utils/functions/dom";
-import { formatDate, formatNumber, toMultipleDigits } from "@common/utils/functions/formatting";
+import { formatDate, formatNumber } from "@common/utils/functions/formatting";
 import { addXHRListener } from "@common/utils/functions/listeners";
 import { requireElement } from "@common/utils/functions/requires";
 import { createCheckbox } from "@common/utils/elements/checkbox/checkbox";
@@ -265,27 +265,12 @@ function formatGroupLabel(groupKey: string, groupPeriod = getGroupPeriod()): str
 	const milliseconds = Number(groupKey);
 	if (!Number.isFinite(milliseconds)) return groupKey;
 
-	if (groupPeriod === "month") return formatMonthGroupLabel(milliseconds);
-	if (groupPeriod === "year") return String(new Date(milliseconds).getUTCFullYear());
-
-	const date = formatUtcDate(milliseconds);
-	return groupPeriod === "week" ? `Week of ${date}` : date;
-}
-
-function formatUtcDate(milliseconds: number): string {
 	const date = new Date(milliseconds);
-	const formattingDate = settings.formatting.tct ? date : new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
-	return formatDate(formattingDate, { showYear: true });
-}
+	if (groupPeriod === "month") return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+	if (groupPeriod === "year") return String(date.getUTCFullYear());
 
-function formatMonthGroupLabel(milliseconds: number): string {
-	const date = new Date(milliseconds);
-	const month = toMultipleDigits(date.getUTCMonth() + 1);
-	const year = date.getUTCFullYear();
-
-	if (settings.formatting.date === "us") return `${month}/${year}`;
-	if (settings.formatting.date === "eu") return `${month}.${year}`;
-	return `${year}-${month}`;
+	const formattedDate = formatDate({ milliseconds }, { showYear: true });
+	return groupPeriod === "week" ? `Week of ${formattedDate}` : formattedDate;
 }
 
 function getCityItemId(item: DecodedCityItem | InternalCityItem): number {

--- a/src/common/pages/city-page.ts
+++ b/src/common/pages/city-page.ts
@@ -6,14 +6,23 @@ declare global {
 	}
 }
 
-interface TornCityObject {
-	model: {
-		get(): Omit<MapData, "territoryUserItems"> & { territoryUserItems: InternalCityItem[] };
-		get(key: "territoryUserItems"): InternalCityItem[];
-	};
+export interface TornCityObject {
+	model: TornCityModel;
+	map?: TornCityMapRuntime;
 }
 
-type MapData = {
+export interface TornCityModel {
+	get(): Omit<MapData, "territoryUserItems"> & { territoryUserItems: InternalCityItem[] };
+	get(key: "territoryUserItems"): InternalCityItem[];
+}
+
+export interface TornCityMapRuntime {
+	lmap?: unknown;
+	minZoom?: number;
+	getLPoint?(point: [number, number]): unknown;
+}
+
+export type MapData = {
 	mapConstants: {
 		TERRITORY_RESPECT_PRICE: number;
 		TERRITORY_PRICE_COEF: number;
@@ -104,7 +113,7 @@ type MapData = {
 	territoryUserItems: string;
 };
 
-interface FactionData {
+export interface FactionData {
 	image: string;
 	colour: string;
 	colourID: number;

--- a/src/common/pages/city-page.ts
+++ b/src/common/pages/city-page.ts
@@ -9,6 +9,7 @@ declare global {
 interface TornCityObject {
 	model: {
 		get(): Omit<MapData, "territoryUserItems"> & { territoryUserItems: InternalCityItem[] };
+		get(key: "territoryUserItems"): InternalCityItem[];
 	};
 }
 

--- a/src/common/utils/data/default-database.ts
+++ b/src/common/utils/data/default-database.ts
@@ -442,6 +442,8 @@ export const DEFAULT_STORAGE = {
 			city: {
 				items: new DefaultSetting("boolean", true),
 				combineDuplicates: new DefaultSetting("boolean", true),
+				groupByPeriod: new DefaultSetting("boolean", false),
+				groupByPeriodUnit: new DefaultSetting("string", "day"),
 			},
 			joblist: {
 				specials: new DefaultSetting("boolean", true),

--- a/src/common/utils/functions/script-injector.ts
+++ b/src/common/utils/functions/script-injector.ts
@@ -6,8 +6,15 @@ export interface ScriptInjector {
 	getWindow(): Window;
 	injectFetch(): void;
 	injectXHR(): void;
-	injectCityItemsMap?(): void;
+	injectCityItemsMap(): void;
 }
+
+export const DEFAULT_SCRIPT_INJECTOR: ScriptInjector = {
+	getWindow: () => window,
+	injectXHR() {},
+	injectFetch() {},
+	injectCityItemsMap() {},
+};
 
 declare global {
 	interface Window {

--- a/src/common/utils/functions/script-injector.ts
+++ b/src/common/utils/functions/script-injector.ts
@@ -6,6 +6,7 @@ export interface ScriptInjector {
 	getWindow(): Window;
 	injectFetch(): void;
 	injectXHR(): void;
+	injectCityItemsMap?(): void;
 }
 
 declare global {

--- a/src/common/utils/team.ts
+++ b/src/common/utils/team.ts
@@ -351,6 +351,13 @@ export const TEAM: TeamMember[] = [
 		torn: 4166912,
 		color: "#33873c",
 	},
+	{
+		name: "Manuel",
+		title: "Developer",
+		core: false,
+		torn: 3747263,
+		color: "#4f8cff",
+	},
 ];
 
 interface Contributor {

--- a/src/extension/assets/changelog.json
+++ b/src/extension/assets/changelog.json
@@ -17,7 +17,8 @@
 				{ "message": "Don't send duplicate planned npc attack notifications.", "contributor": "DeKleineKobini" },
 				{ "message": "Show a list of items in your city map again after the map update.", "contributor": "DeKleineKobini" },
 				{ "message": "Fix 'Drug Details' immediately disappearing on the items page.", "contributor": "DeKleineKobini" },
-				{ "message": "Show crime achievements again.", "contributor": "DeKleineKobini" }
+				{ "message": "Show crime achievements again.", "contributor": "DeKleineKobini" },
+				{ "message": "Restore item highlighting and searching in the 'City Items' map after Torn's map update.", "contributor": "Manuel" }
 			],
 			"changes": [
 				{ "message": "Increase the max height of 'Resizable Chat' to about 4 lines.", "contributor": "DeKleineKobini" },

--- a/src/extension/assets/changelog.json
+++ b/src/extension/assets/changelog.json
@@ -10,7 +10,8 @@
 				{
 					"message": "Report some data to the TornTools developers when a response looks to be from another player (fully opt-in).",
 					"contributor": "DeKleineKobini"
-				}
+				},
+				{ "message": "Allow grouping and filtering of city items by their spawning date.", "contributor": "Manuel" }
 			],
 			"fixes": [
 				{ "message": "Keep everything intact even if SpeechSynthesis is disabled in the browser.", "contributor": "DeKleineKobini" },

--- a/src/extension/entrypoints/city-items--inject.ts
+++ b/src/extension/entrypoints/city-items--inject.ts
@@ -1,0 +1,8 @@
+import { injectCityItemsMapListeners } from "@common/features/city-items/city-items-map";
+
+// noinspection JSUnusedGlobalSymbols
+export default defineUnlistedScript(() => {
+	injectCityItemsMapListeners();
+
+	console.log("Script Injected - City Items Map Hooks");
+});

--- a/src/extension/entrypoints/fetch--inject.ts
+++ b/src/extension/entrypoints/fetch--inject.ts
@@ -1,13 +1,9 @@
 import { setScriptInjector } from "@common/utils/context";
-import { injectFetchListeners, RequestListenerInjector } from "@common/utils/functions/script-injector";
+import { DEFAULT_SCRIPT_INJECTOR, injectFetchListeners, RequestListenerInjector } from "@common/utils/functions/script-injector";
 
 // noinspection JSUnusedGlobalSymbols
 export default defineUnlistedScript(() => {
-	setScriptInjector({
-		getWindow: () => window,
-		injectXHR: () => {},
-		injectFetch: () => {},
-	});
+	setScriptInjector(DEFAULT_SCRIPT_INJECTOR);
 	new RequestListenerInjector(injectFetchListeners).inject();
 
 	console.log("Script Injected - Fetch Interception");

--- a/src/extension/entrypoints/xhr--inject.ts
+++ b/src/extension/entrypoints/xhr--inject.ts
@@ -1,13 +1,9 @@
 import { setScriptInjector } from "@common/utils/context";
-import { injectXhrListeners, RequestListenerInjector } from "@common/utils/functions/script-injector";
+import { DEFAULT_SCRIPT_INJECTOR, injectXhrListeners, RequestListenerInjector } from "@common/utils/functions/script-injector";
 
 // noinspection JSUnusedGlobalSymbols
 export default defineUnlistedScript(() => {
-	setScriptInjector({
-		getWindow: () => window,
-		injectXHR: () => {},
-		injectFetch: () => {},
-	});
+	setScriptInjector(DEFAULT_SCRIPT_INJECTOR);
 	new RequestListenerInjector(injectXhrListeners).inject();
 
 	console.log("Script Injected - XHR Interception");

--- a/src/extension/runtime/extension-context.ts
+++ b/src/extension/runtime/extension-context.ts
@@ -40,7 +40,7 @@ export function registerExtensionContext() {
 	setStaticItemResolver(ExtensionItemResolver);
 }
 
-const ExtensionScriptInjector: ScriptInjector & { injectedFetch: boolean; injectedXHR: boolean } = {
+const ExtensionScriptInjector: ScriptInjector & { injectedFetch: boolean; injectedXHR: boolean; injectedCityItemsMap: boolean } = {
 	getWindow(): Window {
 		return usingFirefox() ? window.wrappedJSObject! : window;
 	},
@@ -57,6 +57,13 @@ const ExtensionScriptInjector: ScriptInjector & { injectedFetch: boolean; inject
 
 		executeScript(browser.runtime.getURL("/xhr--inject.js"), false);
 		this.injectedXHR = true;
+	},
+	injectedCityItemsMap: false,
+	injectCityItemsMap() {
+		if (this.injectedCityItemsMap) return;
+
+		executeScript(browser.runtime.getURL("/city-items--inject.js"), false);
+		this.injectedCityItemsMap = true;
 	},
 };
 

--- a/src/userscripts/runtime/script-context.ts
+++ b/src/userscripts/runtime/script-context.ts
@@ -22,6 +22,7 @@ import {
 } from "@common/utils/data/database";
 import { DEFAULT_STORAGE, getDefaultStorage } from "@common/utils/data/default-database";
 import { injectFetchListeners, injectXhrListeners, RequestListenerInjector, type ScriptInjector } from "@common/utils/functions/script-injector";
+import { injectCityItemsMapListeners } from "@features/city-items/city-items-map";
 import type { Feature } from "@features/feature";
 import type { FeatureManager } from "@features/feature-manager";
 import { TTScriptStorage } from "@userscripts/runtime/script-storage";
@@ -72,8 +73,13 @@ class ScriptFeatureManager implements FeatureManager {
 	}
 }
 
+function injectUserscriptCityItemsMapListeners() {
+	injectCityItemsMapListeners(unsafeWindow);
+}
+
 const fetchListenerInjector = new RequestListenerInjector(injectFetchListeners);
 const xhrListenerInjector = new RequestListenerInjector(injectXhrListeners);
+const cityItemsMapListenerInjector = new RequestListenerInjector(injectUserscriptCityItemsMapListeners);
 
 const UserscriptScriptInjector: ScriptInjector = {
 	getWindow(): Window {
@@ -84,6 +90,9 @@ const UserscriptScriptInjector: ScriptInjector = {
 	},
 	injectXHR() {
 		xhrListenerInjector.inject();
+	},
+	injectCityItemsMap() {
+		cityItemsMapListenerInjector.inject();
 	},
 };
 


### PR DESCRIPTION
## Summary

Restores City Items map highlighting/searching after Torn moved city item markers from DOM image markers to Leaflet/canvas rendering.

- Resolves city item IDs directly from Torn city item payloads instead of matching by title.
- Adds a lightweight page-context Leaflet overlay bridge for City Items, without patching Torn/Leaflet marker internals.
- Renders separate TornTools overlay markers from already-loaded city item coordinates.
- Restores list hover/search highlighting on the map with a reduced, non-invasive overlay size.
- Keeps item collection tied to trusted user clicks from the list or map overlay.
- Updates the City Items list/value/overlays after successful pickup.
- Adds extension and userscript injection support for the overlay bridge.

## Safety / privacy notes

- No new automatic Torn page scraping or background collection.
- Uses the existing `city.php?step=mapData` XHR/model data already loaded on the visible City page.
- Pickup POSTs only happen from trusted user clicks.
- The page/content bridge serializes event payloads to JSON strings for Firefox compatibility.

## Screenshots

### Restored City Items list + map overlays

![Restored City Items list and map overlays](https://raw.githubusercontent.com/manuelcecchetto/torntools_extension/pr-assets/.github/pr-assets/city-items-overview.jpg)

### Pickup toast / list update flow

![City item pickup toast](https://raw.githubusercontent.com/manuelcecchetto/torntools_extension/pr-assets/.github/pr-assets/city-items-pickup-toast.png)

## Validation

- `bunx tsc --noEmit`
- `bunx biome check --write src/common/features/city-items/city-items.ts src/common/features/city-items/city-items-map.ts src/common/features/city-items/city-items.css src/extension/assets/changelog.json`
- `bun run build`
- `bun run build:userscripts`

Also ran a pre-PR parallel code/security review and addressed the findings before opening this PR:

- fixed last-item empty-list reduce crash
- hardened collection so public page-context events cannot trigger pickup POSTs
- switched bridge details to JSON strings for Firefox-safe page/content communication
- added a per-entry in-flight guard for collection clicks
- made pickup response handling fail closed for unrecognized non-empty text responses
- added the required changelog entry
