### PR TITLE
fix: restore City Items highlight toggle

### DIFF
--- a/src/common/features/city-items/city-items.css
+++ b/src/common/features/city-items/city-items.css
@@ -3,7 +3,7 @@
  */
 #map .tt-city-item-overlay.city-item {
 	box-sizing: border-box;
-	display: block !important;
+	display: none !important;
 	width: 38px !important;
 	height: 38px !important;
 	margin-left: -19px !important;
@@ -13,6 +13,11 @@
 	background: transparent;
 	cursor: pointer;
 	pointer-events: auto !important;
+}
+
+#map.highlight-items .tt-city-item-overlay.city-item,
+#map .tt-city-item-overlay.city-item.force-hover {
+	display: block !important;
 }
 
 #map .tt-city-item-overlay.city-item .tt-city-item-overlay-content {

--- a/src/common/features/city-items/city-items.ts
+++ b/src/common/features/city-items/city-items.ts
@@ -1,7 +1,7 @@
 import "./city-items.css";
 import { type DecodedCityItem, type InternalCityItem, isMapData } from "@common/pages/city-page";
 import { FEATURE_MANAGER, ITEM_RESOLVER, SCRIPT_INJECTOR, ttStorage } from "@common/utils/context";
-import { settings } from "@common/utils/data/database";
+import { filters, settings } from "@common/utils/data/database";
 import { createCheckbox } from "@common/utils/elements/checkbox/checkbox";
 import { createSelect } from "@common/utils/elements/select/select";
 import { displayAlert } from "@common/utils/functions/alerts";
@@ -309,11 +309,30 @@ async function showCityItemsContainer(items: CityItem[]) {
 	await requireElement("#map .leaflet-zoom-animated");
 
 	if (!contentElement || !document.contains(contentElement)) {
-		const { content } = createContainer("City Items", { class: "mt10", alwaysContent: true, nextElement: document.querySelector("#tab-menu") });
+		const { content, options } = createContainer("City Items", { class: "mt10", alwaysContent: true, nextElement: document.querySelector("#tab-menu") });
 		contentElement = content;
+		showHighlightControl(options);
 	}
 
 	setCityItems(items);
+}
+
+function showHighlightControl(options: HTMLElement) {
+	const checkbox = createCheckbox({ description: "Highlight items" });
+	checkbox.setChecked(filters.city.highlightItems);
+	setMapHighlight(filters.city.highlightItems);
+	checkbox.onChange(() => {
+		const highlightItems = checkbox.isChecked();
+
+		setMapHighlight(highlightItems);
+		void ttStorage.change({ filters: { city: { highlightItems } } });
+	});
+
+	options.appendChild(checkbox.element);
+}
+
+function setMapHighlight(state: boolean) {
+	document.querySelector("#map")?.classList.toggle("highlight-items", state);
 }
 
 function setCityItems(items: CityItem[]) {
@@ -872,6 +891,7 @@ function removeHighlight() {
 	resetVisibleGroups();
 	collectingEntries.clear();
 	clearForcedHighlights();
+	setMapHighlight(false);
 	dispatchMapEvent(CITY_ITEMS_MAP_EVENTS.CLEAR);
 	document.removeEventListener("click", handleMapOverlayClick, true);
 }

--- a/src/common/utils/data/default-database.ts
+++ b/src/common/utils/data/default-database.ts
@@ -620,6 +620,9 @@ export const DEFAULT_STORAGE = {
 			defense: new DefaultSetting("boolean", false),
 			dexterity: new DefaultSetting("boolean", false),
 		},
+		city: {
+			highlightItems: new DefaultSetting("boolean", true),
+		},
 		bounties: {
 			maxLevel: new DefaultSetting("number", 100),
 			hideUnavailable: new DefaultSetting("boolean", false),

--- a/src/extension/assets/changelog.json
+++ b/src/extension/assets/changelog.json
@@ -9,7 +9,8 @@
 				{ "message": "Block most pages from running on the recaptcha page.", "contributor": "DeKleineKobini" },
 				{ "message": "Fix the city items value no longer always being visible.", "contributor": "DeKleineKobini" },
 				{ "message": "Show average personal stats again.", "contributor": "DeKleineKobini" },
-				{ "message": "Fix the city items not always showing up when you have no items present.", "contributor": "DeKleineKobini" }
+				{ "message": "Fix the city items not always showing up when you have no items present.", "contributor": "DeKleineKobini" },
+				{ "message": "Reintroduce the 'Highlight items' checkbox for City Items map overlays.", "contributor": "Manuel" }
 			],
 			"changes": [],
 			"removed": [],

--- a/src/userscripts/entries/city-items/metadata.ts
+++ b/src/userscripts/entries/city-items/metadata.ts
@@ -3,7 +3,7 @@ import type { UserscriptMetadata } from "@userscripts/entries/userscript-metadat
 const metadata: UserscriptMetadata = {
 	name: "City Items",
 	description: "List all available items in your city and allow you to collect them with a single click.",
-	version: "beta-1.0.3",
+	version: "beta-1.0.4",
 	matches: ["https://*.torn.com/city.php*"],
 	runAt: "document-start",
 	connect: ["torntools.tornplayground.eu"],


### PR DESCRIPTION
**Torn username and ID:**
Manuel [3747263]

- [x] Read `CONTRIBUTING.md`.
- [x] Added your name in `extension/scripts/global/team.ts` file. Already listed as Manuel.
- [x] Update the unreleased version of `extension/changelog.js` file

Is this PR:
- [ ] for a new feature ?
- [x] an issue fix ?
- [ ] a developer QoL PR ?

**Purpose of PR:**
Reintroduces the City Items accordion header checkbox for toggling item highlights on the city map.

This restores the pre-9.0.8 behavior from 9.0.6/9.0.7:
- the `Highlight items` checkbox appears in the City Items header
- the preference is stored in `filters.city.highlightItems`
- city map overlays are hidden when unchecked
- hovering an item in the list still temporarily shows its marker

Validation:
- `python3 -m json.tool src/extension/assets/changelog.json >/dev/null`
- `bun x tsc --noEmit --pretty false`
- `bun run build:chrome`

**Linked issues:**
None
