### PR TITLE
fix: restore faction activity filters

### DIFF
--- a/src/common/features/faction-member-filter/faction-member-filter.ts
+++ b/src/common/features/faction-member-filter/faction-member-filter.ts
@@ -6,7 +6,7 @@ import { createTextbox } from "@common/utils/elements/textbox/textbox";
 import { hasAPIData } from "@common/utils/functions/api";
 import { createContainer, findContainer, removeContainer } from "@common/utils/functions/containers";
 import { elementBuilder, findAllElements, isElement } from "@common/utils/functions/dom";
-import { createFilterEnabledFunnel, createFilterSection, createStatistics, getSpecialIcons } from "@common/utils/functions/filters";
+import { createFilterEnabledFunnel, createFilterSection, createStatistics, getSpecialIcons, getUserActivity } from "@common/utils/functions/filters";
 import { CUSTOM_LISTENERS, EVENT_CHANNELS, triggerCustomListener } from "@common/utils/functions/listeners";
 import { requireElement } from "@common/utils/functions/requires";
 import { SPECIAL_FILTER_ICONS } from "@common/utils/functions/torn";
@@ -282,7 +282,7 @@ async function applyFilter() {
 	for (const li of findAllElements(".members-list .table-body > li")) {
 		// Activity
 		if (activity.length) {
-			const userActivity = li.querySelector("[class*='userOnlineStatusIcon___']").getAttribute("alt");
+			const userActivity = getUserActivity(li);
 
 			if (!activity.some((x) => x.trim() === userActivity)) {
 				hideRow(li);

--- a/src/common/features/ranked-war-filter/ranked-war-filter.ts
+++ b/src/common/features/ranked-war-filter/ranked-war-filter.ts
@@ -5,7 +5,7 @@ import { createTextbox } from "@common/utils/elements/textbox/textbox";
 import { hasAPIData } from "@common/utils/functions/api";
 import { createContainer, findContainer, removeContainer } from "@common/utils/functions/containers";
 import { elementBuilder, findAllElements } from "@common/utils/functions/dom";
-import { createFilterEnabledFunnel, createFilterSection, createStatistics } from "@common/utils/functions/filters";
+import { createFilterEnabledFunnel, createFilterSection, createStatistics, getUserActivity } from "@common/utils/functions/filters";
 import { addFetchListener, CUSTOM_LISTENERS, EVENT_CHANNELS, triggerCustomListener } from "@common/utils/functions/listeners";
 import { requireElement } from "@common/utils/functions/requires";
 import { getPageStatus, RANK_TRIGGERS } from "@common/utils/functions/torn";
@@ -239,7 +239,7 @@ interface RankedWarFilters {
 
 function filterRow(row: HTMLElement, filters: Partial<RankedWarFilters>, individual: boolean) {
 	if (filters.activity) {
-		const activity = row.querySelector("[class*='userOnlineStatusIcon___']").getAttribute("alt");
+		const activity = getUserActivity(row);
 		if (filters.activity.length && !filters.activity.some((x) => x.trim() === activity)) {
 			hide("activity");
 			return;

--- a/src/common/utils/functions/filters.ts
+++ b/src/common/utils/functions/filters.ts
@@ -12,6 +12,7 @@ import { camelCase } from "@common/utils/functions/formatting";
 import { WEAPON_BONUSES } from "@common/utils/functions/torn";
 import { getUUID } from "@common/utils/functions/utilities";
 import { PHFillFunnel, PHFillFunnelX } from "@common/utils/icons/phosphor-icons";
+import type { UserLastActionStatusEnum } from "tornapi-typescript";
 
 export type SpecialFilterValue = "both" | "yes" | "no" | "none";
 
@@ -61,6 +62,15 @@ export const defaultFactionsItems: FilterOption[] = [
 export const FILTER_REGEXES = {
 	activity: /Online|Idle|Offline/g,
 } as const;
+
+export type UserActivityStatus = Lowercase<UserLastActionStatusEnum>;
+
+export function getUserActivity(element: ParentNode): UserActivityStatus | "" {
+	const icon = element.querySelector("[class*='userOnlineStatusIcon___']");
+	const label = icon?.getAttribute("alt") || icon?.closest("[aria-label]")?.getAttribute("aria-label") || "";
+
+	return (label.match(/\b(online|idle|offline)\b/i)?.[1].toLowerCase() as UserActivityStatus | undefined) ?? "";
+}
 
 type FilterCallback = (() => void) | (() => Promise<void>);
 interface CommonOptions {

--- a/src/extension/assets/changelog.json
+++ b/src/extension/assets/changelog.json
@@ -13,7 +13,8 @@
 				{ "message": "Fix the city items value no longer always being visible.", "contributor": "DeKleineKobini" },
 				{ "message": "Show average personal stats again.", "contributor": "DeKleineKobini" },
 				{ "message": "Fix the city items not always showing up when you have no items present.", "contributor": "DeKleineKobini" },
-				{ "message": "Reintroduce the 'Highlight items' checkbox for City Items map overlays.", "contributor": "Manuel" }
+				{ "message": "Reintroduce the 'Highlight items' checkbox for City Items map overlays.", "contributor": "Manuel" },
+				{ "message": "Fix Activity filters for faction members and ranked wars after Torn's user status markup update.", "contributor": "Manuel" }
 			],
 			"changes": [{ "message": "Adjust the travel time and cost for the 'Travel Table'.", "contributor": "DeKleineKobini" }],
 			"removed": [],

--- a/src/userscripts/entries/faction-member-filter/metadata.ts
+++ b/src/userscripts/entries/faction-member-filter/metadata.ts
@@ -3,7 +3,7 @@ import type { UserscriptMetadata } from "@userscripts/entries/userscript-metadat
 const metadata: UserscriptMetadata = {
 	name: "Faction Member Filter",
 	description: "Filter the list of members in a faction.",
-	version: "1.0.1",
+	version: "1.0.2",
 	matches: ["https://*.torn.com/factions.php*"],
 	runAt: "document-end",
 };

--- a/src/userscripts/entries/ranked-war-filter/metadata.ts
+++ b/src/userscripts/entries/ranked-war-filter/metadata.ts
@@ -3,7 +3,7 @@ import type { UserscriptMetadata } from "@userscripts/entries/userscript-metadat
 const metadata: UserscriptMetadata = {
 	name: "Ranked War Filter",
 	description: "Filter the ranked war views.",
-	version: "1.0.1",
+	version: "1.0.2",
 	matches: ["https://*.torn.com/factions.php*"],
 	runAt: "document-end",
 };


### PR DESCRIPTION
**Torn username and ID:**
Manuel [3747263]

- [x] Read `CONTRIBUTING.md`.
- [x] Added your name in `extension/scripts/global/team.ts` file. (Already listed in `src/common/utils/team.ts`.)
- [x] Update the unreleased version of `extension/changelog.js` file

Is this PR:
- [ ] for a new feature ?
- [x] an issue fix ?
- [ ] a developer QoL PR ?

**Purpose of PR:**
Fix the Faction Member Filter and Ranked War Filter activity filters after Torn removed the status value from the online-status SVG `alt` attribute and moved it to the wrapping `aria-label`.

This keeps support for the old `alt` markup, falls back to the new `aria-label` markup, normalizes the status value, and bumps the affected userscript versions.

Validation:
- `bunx tsc --noEmit`
- `bun run build:chrome`
- `bun run build:userscripts`

**Linked issues:**
None
