### PR TITLE
fix: prevent Quick Items activating during mobile swipes

### DIFF
--- a/src/common/features/faction-quick-items/faction-quick-items.ts
+++ b/src/common/features/faction-quick-items/faction-quick-items.ts
@@ -9,6 +9,7 @@ import { createContainer, findContainer, removeContainer } from "@common/utils/f
 import { elementBuilder, findAllElements, findParent, isElement, mobile, tablet } from "@common/utils/functions/dom";
 import { addCustomListener, EVENT_CHANNELS } from "@common/utils/functions/events";
 import { formatTime } from "@common/utils/functions/formatting";
+import { createSwipeSafeClickEvents } from "@common/utils/functions/gestures";
 import { requireElement } from "@common/utils/functions/requires";
 import { getItemEnergy, getPageStatus, getUserEnergy } from "@common/utils/functions/torn";
 import { PHFillPlus, PHX } from "@common/utils/icons/phosphor-icons";
@@ -215,7 +216,7 @@ function addQuickItem(data: { id: string | number }, temporary = false) {
 		class: temporary ? "temp item" : "item",
 		dataset: data,
 		events: {
-			click: async () => {
+			...createSwipeSafeClickEvents(async () => {
 				if (itemWrap.classList.contains("removable")) {
 					itemWrap.remove();
 					itemWrap.dispatchEvent(new Event("mouseout"));
@@ -339,7 +340,7 @@ function addQuickItem(data: { id: string | number }, temporary = false) {
 						}
 					});
 				}
-			},
+			}),
 			dragstart(event) {
 				event.dataTransfer.effectAllowed = "move";
 				event.dataTransfer.setDragImage(event.currentTarget as Element, 0, 0);
@@ -371,7 +372,7 @@ function addQuickItem(data: { id: string | number }, temporary = false) {
 			},
 		},
 		attributes: {
-			draggable: true,
+			draggable: !(mobile || tablet),
 		},
 	});
 	switch (id) {
@@ -416,16 +417,14 @@ function addQuickItem(data: { id: string | number }, temporary = false) {
 		class: "tt-close-icon",
 		children: [PHX()],
 		attributes: { title: "Remove quick access." },
-		events: {
-			click: async (event) => {
-				event.stopPropagation();
-				itemWrap.dispatchEvent(new Event("mouseout"));
-				closeIcon.dispatchEvent(new Event("mouseout"));
-				itemWrap.remove();
+		events: createSwipeSafeClickEvents(async (event) => {
+			event.stopPropagation();
+			itemWrap.dispatchEvent(new Event("mouseout"));
+			closeIcon.dispatchEvent(new Event("mouseout"));
+			itemWrap.remove();
 
-				await saveQuickItems();
-			},
-		},
+			await saveQuickItems();
+		}),
 	});
 	itemWrap.appendChild(closeIcon);
 	innerContent.appendChild(itemWrap);

--- a/src/common/features/quick-crimes/quick-crimes.ts
+++ b/src/common/features/quick-crimes/quick-crimes.ts
@@ -244,7 +244,7 @@ async function loadCrimes() {
 				action: `crimes.php?step=${step}`,
 				method: "post",
 				name: "crimes",
-				draggable: true,
+				draggable: !isTouchDevice,
 			},
 		});
 		innerContent.appendChild(itemWrap);

--- a/src/common/features/quick-items/quick-items.ts
+++ b/src/common/features/quick-items/quick-items.ts
@@ -9,6 +9,7 @@ import { createContainer, findContainer, removeContainer } from "@common/utils/f
 import { elementBuilder, findAllElements, findParent, isElement, mobile, tablet } from "@common/utils/functions/dom";
 import { addCustomListener, EVENT_CHANNELS, triggerCustomListener } from "@common/utils/functions/events";
 import { formatTime } from "@common/utils/functions/formatting";
+import { createSwipeSafeClickEvents } from "@common/utils/functions/gestures";
 import { addFetchListener, addXHRListener } from "@common/utils/functions/listeners";
 import { requireContent, requireItemsLoaded } from "@common/utils/functions/requires";
 import {
@@ -168,7 +169,7 @@ function addQuickItem(data: QuickItem & { equipPosition?: false | number }, temp
 		class: temporary ? "temp item" : "item",
 		dataset: data,
 		events: {
-			click: async () => {
+			...createSwipeSafeClickEvents(async () => {
 				if (itemWrap.classList.contains("removable")) {
 					itemWrap.remove();
 					itemWrap.dispatchEvent(new Event("mouseout"));
@@ -358,7 +359,7 @@ function addQuickItem(data: QuickItem & { equipPosition?: false | number }, temp
 							);
 					}
 				});
-			},
+			}),
 			dragstart(event) {
 				if (!isElement(event.currentTarget)) return;
 
@@ -391,7 +392,7 @@ function addQuickItem(data: QuickItem & { equipPosition?: false | number }, temp
 			},
 		},
 		attributes: {
-			draggable: true,
+			draggable: !(mobile || tablet),
 		},
 	});
 	itemWrap.appendChild(elementBuilder({ type: "div", class: "pic", attributes: { style: `background-image: url(/images/items/${id}/medium.png)` } }));
@@ -418,16 +419,14 @@ function addQuickItem(data: QuickItem & { equipPosition?: false | number }, temp
 		class: "tt-close-icon",
 		children: [PHX()],
 		attributes: { title: "Remove quick access." },
-		events: {
-			click: async (event) => {
-				event.stopPropagation();
-				itemWrap.dispatchEvent(new Event("mouseout"));
-				closeIcon.dispatchEvent(new Event("mouseout"));
-				itemWrap.remove();
+		events: createSwipeSafeClickEvents(async (event) => {
+			event.stopPropagation();
+			itemWrap.dispatchEvent(new Event("mouseout"));
+			closeIcon.dispatchEvent(new Event("mouseout"));
+			itemWrap.remove();
 
-				await saveQuickItems();
-			},
-		},
+			await saveQuickItems();
+		}),
 	});
 	itemWrap.appendChild(closeIcon);
 	innerContent.appendChild(itemWrap);

--- a/src/common/utils/functions/gestures.ts
+++ b/src/common/utils/functions/gestures.ts
@@ -1,0 +1,74 @@
+const TAP_MOVE_THRESHOLD_PX = 8;
+const SYNTHETIC_CLICK_SUPPRESS_MS = 500;
+
+type ClickHandler = (event: MouseEvent) => void | Promise<void>;
+
+/**
+ * Mobile browsers can emit a synthetic click after a touch sequence even when the
+ * user was trying to swipe/scroll. Use this for destructive/one-tap actions so a
+ * swipe that starts on the element is not treated as an activation.
+ */
+export function createSwipeSafeClickEvents(onClick: ClickHandler) {
+	let touchStart: { x: number; y: number } | null = null;
+	let touchMoved = false;
+	let suppressNextClick = false;
+	let suppressTimeout: ReturnType<typeof window.setTimeout> | undefined;
+
+	function clearSuppressClick() {
+		suppressNextClick = false;
+		if (suppressTimeout !== undefined) {
+			window.clearTimeout(suppressTimeout);
+			suppressTimeout = undefined;
+		}
+	}
+
+	function markSuppressNextClick() {
+		suppressNextClick = true;
+		if (suppressTimeout !== undefined) window.clearTimeout(suppressTimeout);
+		suppressTimeout = window.setTimeout(clearSuppressClick, SYNTHETIC_CLICK_SUPPRESS_MS);
+	}
+
+	function clearTouch() {
+		touchStart = null;
+		touchMoved = false;
+	}
+
+	return {
+		touchstart(event: TouchEvent) {
+			if (event.touches.length !== 1) {
+				clearTouch();
+				return;
+			}
+
+			const touch = event.touches[0];
+			touchStart = { x: touch.clientX, y: touch.clientY };
+			touchMoved = false;
+		},
+		touchmove(event: TouchEvent) {
+			if (!touchStart || event.touches.length !== 1) return;
+
+			const touch = event.touches[0];
+			const movedX = Math.abs(touch.clientX - touchStart.x);
+			const movedY = Math.abs(touch.clientY - touchStart.y);
+
+			if (Math.max(movedX, movedY) >= TAP_MOVE_THRESHOLD_PX) touchMoved = true;
+		},
+		touchend() {
+			if (touchMoved) markSuppressNextClick();
+			clearTouch();
+		},
+		touchcancel() {
+			clearTouch();
+		},
+		click(event: MouseEvent) {
+			if (suppressNextClick) {
+				clearSuppressClick();
+				event.preventDefault();
+				event.stopPropagation();
+				return;
+			}
+
+			return onClick(event);
+		},
+	};
+}

--- a/src/extension/assets/changelog.json
+++ b/src/extension/assets/changelog.json
@@ -9,7 +9,8 @@
 				{ "message": "Resolve wrong values being applied in the Racing Filter.", "contributor": "DeKleineKobini" },
 				{ "message": "Fix an issue where the 'Creator Message' is not always shown.", "contributor": "DeKleineKobini" },
 				{ "message": "Fix 'Hide Icons' not working with the flyout bar.", "contributor": "DeKleineKobini" },
-				{ "message": "Resolve an issue with the activity filter not working everywhere.", "contributor": "DeKleineKobini" }
+				{ "message": "Resolve an issue with the activity filter not working everywhere.", "contributor": "DeKleineKobini" },
+				{ "message": "Prevent mobile swipes over Quick Items from using items accidentally.", "contributor": "Manuel" }
 			],
 			"changes": [],
 			"removed": [],

--- a/src/extension/assets/changelog.json
+++ b/src/extension/assets/changelog.json
@@ -10,10 +10,10 @@
 				{ "message": "Fix an issue where the 'Creator Message' is not always shown.", "contributor": "DeKleineKobini" },
 				{ "message": "Fix 'Hide Icons' not working with the flyout bar.", "contributor": "DeKleineKobini" },
 				{ "message": "Resolve an issue with the activity filter not working everywhere.", "contributor": "DeKleineKobini" },
-				{ "message": "Prevent mobile swipes over Quick Items from using items accidentally.", "contributor": "Manuel" }
+				{ "message": "Prevent mobile swipes over (Faction) Quick Items from using items accidentally.", "contributor": "Manuel" }
 			],
 			"changes": [],
-			"removed": [],
+			"removed": [{ "message": "Don't allow (Faction) Quick Items drag and drop on touch devices, thanks to the slidebar.", "contributor": "Manuel" }],
 			"technical": [
 				{ "message": "Refactor the filter helpers and apply it to the 'Abroad Items Filter' and 'Hospital Filter'.", "contributor": "DeKleineKobini" },
 				{ "message": "Debounce the cache persisting, which might resolve performance issues.", "contributor": "DeKleineKobini" },


### PR DESCRIPTION
**Torn username and ID:**
Manuel [3747263]

- [x] Read `CONTRIBUTING.md`.
- [x] Added your name in `extension/scripts/global/team.ts` file. Already listed as Manuel.
- [x] Update the unreleased version of `extension/changelog.js` file. Updated `src/extension/assets/changelog.json`.

Is this PR:
- [ ] for a new feature ?
- [x] an issue fix ?
- [ ] a developer QoL PR ?

**Purpose of PR:**
Prevent Quick Items and Faction Quick Items from accidentally activating after a mobile/tablet swipe, such as Torn's flyout sidebar gesture.

This PR:
- adds a reusable swipe-safe click helper that suppresses the next synthetic click after a moved touch sequence
- applies it to Quick Items, Faction Quick Items, and their remove icons
- disables draggable Quick Items/Faction Quick Items on mobile/tablet and Quick Crimes on touch devices so `drag-drop-touch` does not compete with Torn's swipe gesture
- keeps desktop drag/reorder unchanged

Validation:
- `python3 -m json.tool src/extension/assets/changelog.json >/dev/null`
- `bunx biome check src/common/utils/functions/gestures.ts src/common/features/quick-items/quick-items.ts src/common/features/faction-quick-items/faction-quick-items.ts src/common/features/quick-crimes/quick-crimes.ts src/extension/assets/changelog.json`
- `bunx tsc --noEmit`
- `bun run build:chrome`
- `bun run build:userscripts`

**Linked issues:**
None
