### PR TITLE
fix(userlist-filter): keep non-hospitalized players when Hosp Reason is "no"

### DIFF
--- a/src/common/features/userlist-filter/userlist-filter.ts
+++ b/src/common/features/userlist-filter/userlist-filter.ts
@@ -101,7 +101,7 @@ async function addFilterContainer() {
 					.filter(([, value]) => value !== "both" && value !== "none")
 					.find(([key, value]) => {
 						const hospEl = row.querySelector<HTMLElement>("li[title*='Hospital']");
-						if (!hospEl) return true;
+						if (!hospEl) return value === "yes";
 
 						const reason = hospEl.getAttribute("title").split("<br>")[1];
 						if (key === "other") {

--- a/src/common/utils/team.ts
+++ b/src/common/utils/team.ts
@@ -358,6 +358,13 @@ export const TEAM: TeamMember[] = [
 		torn: 3747263,
 		color: "#4f8cff",
 	},
+	{
+		name: "Ech01337",
+		title: "Developer",
+		core: false,
+		torn: 4270007,
+		color: "teal",
+	},
 ];
 
 interface Contributor {

--- a/src/extension/assets/changelog.json
+++ b/src/extension/assets/changelog.json
@@ -6,6 +6,7 @@
 		"logs": {
 			"features": [],
 			"fixes": [
+				{ "message": "Resolve the 'Userlist Filter' hiding all players when any 'Hosp Reason' is set to no.", "contributor": "Ech01337" },
 				{ "message": "Force browsers to not autocomplete the search chat input field.", "contributor": "DeKleineKobini" },
 				{ "message": "Resolve an issue the special action 'Leave Hospital' with 'Quick Items' on Firefox.", "contributor": "DeKleineKobini" },
 				{ "message": "Display the travel progress in the icon bar again.", "contributor": "DeKleineKobini" },


### PR DESCRIPTION
**Torn username and ID:** Ech01337 [4270007]

- [x] Read `CONTRIBUTING.md`.
- [x] Added your name in `extension/scripts/global/team.ts` file. *(current path: `src/common/utils/team.ts`)*
- [x] Update the unreleased version of `extension/changelog.js` file. *(current path: `src/extension/assets/changelog.json`, under 9.1.1 "Beta")*

Is this PR:
- [ ] for a new feature ?
- [x] an issue fix ?
- [ ] a developer QoL PR ?

**Purpose of PR:**

The **Userlist Filter** hides every player — "Showing 0 of N players" — whenever any **Hosp Reason** sub-filter is left in the N-only (`"no"`) state. That is the default, and since almost nobody on a userlist page is currently in hospital, the entire list is blanked.

Root cause: in `src/common/features/userlist-filter/userlist-filter.ts`, the `hospReason` test early-returns `true` ("exclude this row") for any player **not** in hospital, regardless of direction. The `.find()` callback returns `true` to signal exclusion (`return !match`). Excluding a non-hospitalized player is only correct for `"yes"` ("show only players hospitalized by X"); for `"no"` ("hide players hospitalized by X") they must be kept.

```diff
- if (!hospEl) return true;
+ if (!hospEl) return value === "yes";
```

`"both"` / `"none"` are unaffected (already skipped by the `value !== "both" && value !== "none"` guard on the line above). Verified against the running 9.1.0 build: hidden rows reported `data-hide-reason="hospReason"`; with the change a permissive filter returns all rows, and `"yes"` still narrows to hospitalized players.

**Linked issues:**
#1085
