### PR TITLE
feat: link the popup market headings to their market pages

### DIFF
--- a/src/common/utils/team.ts
+++ b/src/common/utils/team.ts
@@ -365,6 +365,13 @@ export const TEAM: TeamMember[] = [
 		torn: 4270007,
 		color: "teal",
 	},
+	{
+		name: "Aida",
+		title: "Developer",
+		core: false,
+		torn: 4294353,
+		color: "#ff9ec6",
+	},
 ];
 
 interface Contributor {

--- a/src/extension/assets/changelog.json
+++ b/src/extension/assets/changelog.json
@@ -12,7 +12,12 @@
 				},
 				{ "message": "Resolve notification sound not always being the configured volume.", "contributor": "DeKleineKobini" }
 			],
-			"changes": [],
+			"changes": [
+				{
+					"message": "Link the 'Item Market' and 'TornW3B Bazaars' headings in the popup's market search to the item's page on those markets.",
+					"contributor": "Aida"
+				}
+			],
 			"removed": [],
 			"technical": []
 		}

--- a/src/extension/entrypoints/popup/components/market/MarketPrice.svelte
+++ b/src/extension/entrypoints/popup/components/market/MarketPrice.svelte
@@ -4,13 +4,20 @@
 
 	interface MarketPriceProps {
 		title: string;
+		href?: string;
 		listings: { amount: number; price: number }[];
 	}
-	const { title, listings }: MarketPriceProps = $props();
+	const { title, href, listings }: MarketPriceProps = $props();
 </script>
 
 <section class="space-y-1">
-	<h2 class="text-xs font-bold">{title}</h2>
+	<h2 class="text-xs font-bold">
+		{#if href}
+			<a class="hover:underline" {href} target="_blank" rel="noreferrer">{title}</a>
+		{:else}
+			{title}
+		{/if}
+	</h2>
 
 	<Table.Root>
 		<Table.Body>

--- a/src/extension/entrypoints/popup/components/market/SearchResult.svelte
+++ b/src/extension/entrypoints/popup/components/market/SearchResult.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { ttCache } from "@common/utils/data/cache";
-	import { fetchData } from "@common/utils/functions/api-fetcher";
+	import { FETCH_PLATFORMS, fetchData } from "@common/utils/functions/api-fetcher";
 	import type { TornW3BResult } from "@common/utils/functions/api.types";
 	import { formatNumber } from "@common/utils/functions/formatting";
 	import { isSellable } from "@common/utils/functions/torn";
@@ -28,6 +28,12 @@
 	const tornListings = $derived(itemMarket?.itemmarket.listings ?? []);
 	const tornW3bListings = $derived((tornW3bMarket?.listings ?? []).slice(0, 3));
 	const showExternalMarket = $derived(!!$settingsStore?.pages?.popup?.bazaarUsingExternal && !!$settingsStore?.external?.tornw3b);
+	const itemMarketUrl = $derived(
+		selectedItem
+			? `https://www.torn.com/page.php?sid=ItemMarket#/market/view=search&itemID=${selectedItem.id}&itemName=${selectedItem.name}&itemType=${selectedItem.type}`
+			: "",
+	);
+	const tornW3bUrl = $derived(selectedItem ? `${FETCH_PLATFORMS.tornw3b}item/${selectedItem.id}` : "");
 
 	$effect(() => {
 		error = "";
@@ -93,12 +99,7 @@
 			<img class="border-border size-16 rounded-md border object-contain" src={selectedItem.image} alt={selectedItem.name} />
 			<div class="min-w-0 space-y-1">
 				<CardTitle>
-					<a
-						class="hover:underline"
-						href={`https://www.torn.com/page.php?sid=ItemMarket#/market/view=search&itemID=${selectedItem.id}&itemName=${selectedItem.name}&itemType=${selectedItem.type}`}
-						target="_blank"
-						rel="noreferrer"
-					>
+					<a class="hover:underline" href={itemMarketUrl} target="_blank" rel="noreferrer">
 						{selectedItem.name}
 					</a>
 				</CardTitle>
@@ -136,11 +137,16 @@
 				</div>
 			{:else if itemMarket}
 				<div class={cn("grid gap-2", { "grid-cols-2": showExternalMarket })}>
-					<MarketPrice title="Item Market" listings={tornListings.map((listing) => ({ amount: listing.amount, price: listing.price }))} />
+					<MarketPrice
+						title="Item Market"
+						href={itemMarketUrl}
+						listings={tornListings.map((listing) => ({ amount: listing.amount, price: listing.price }))}
+					/>
 
 					{#if showExternalMarket}
 						<MarketPrice
 							title="TornW3B Bazaars"
+							href={tornW3bUrl}
 							listings={tornW3bListings.map((listing) => ({ amount: listing.quantity, price: listing.price }))}
 						/>
 					{/if}


### PR DESCRIPTION
**Torn username and ID:** Aida [4294353]

- [x] Read `CONTRIBUTING.md`.
- [x] Added your name in `src/common/utils/team.ts` file.
- [x] Update the unreleased version of `src/extension/assets/changelog.json` file
- [ ] Bump the versions of all related userscripts — n/a, the popup isn't part of any userscript.

Is this PR:
- [x] for a new feature ?
- [ ] an issue fix ?
- [ ] a developer QoL PR ?

**Purpose of PR:**

In the popup's **Market** tab, the two result headings — **Item Market** and **TornW3B Bazaars** — were plain text. Reading a price there left you with no way to reach the listing it came from short of opening the market and searching the item again by hand; the TornW3B side had no link to it anywhere in the popup at all.

Both headings are now links opening in a new tab:

- **Item Market** → `https://www.torn.com/page.php?sid=ItemMarket#/market/view=search&itemID=…&itemName=…&itemType=…`
- **TornW3B Bazaars** → `https://weav3r.dev/item/<id>`

Implementation:

- `MarketPrice.svelte` takes an optional `href` and only renders the heading as an `<a>` when one is supplied, so the component stays usable for a heading with no destination.
- `SearchResult.svelte` builds both URLs. The Item Market deep link was already constructed inline for the card title, so it is pulled out into a single `itemMarketUrl` derived value and reused rather than duplicated. The TornW3B origin comes from the existing `FETCH_PLATFORMS.tornw3b` constant instead of a second hardcoded host.
- The TornW3B heading link only exists when that panel is shown, which is already gated behind the opt-in `external.tornw3b` + `pages.popup.bazaarUsingExternal` settings — no new external service, no new permission, nothing enabled by default.

Verified `https://weav3r.dev/item/206` resolves to the item page (`TornW3B | Xanax`) before wiring it up.

`bun run types`, `bun run format`, `bun run lint`, `bun test` and `bun run build:chrome` all pass.

**Linked issues:**
Closes #1087
