### PR TITLE
bug: Display Case Worth Regression 

### DIFF
--- a/src/common/features/display-case-worth/display-case-worth.ts
+++ b/src/common/features/display-case-worth/display-case-worth.ts
@@ -37,7 +37,7 @@ async function addWorth() {
 			legacySelections: ["display"],
 		});
 	} catch (error) {
-		await displayError(!!userId, error);
+		await displayError(!userId, error);
 		console.log("TT - Display Cabinet Worth API Error:", error);
 		return;
 	}
@@ -81,7 +81,7 @@ async function displayError(isOwn: boolean, error: any) {
 
 async function displayElement(isOwn: boolean, element: Element) {
 	if (isOwn) {
-		(await requireElement(`.${styles.displayWorth}`)).insertAdjacentElement("beforebegin", element);
+		(await requireElement(".display-cabinet")).insertAdjacentElement("beforebegin", element);
 	} else {
 		await requireElement(".info-msg-cont .ajax-preloader", { invert: true });
 

--- a/src/common/utils/team.ts
+++ b/src/common/utils/team.ts
@@ -383,7 +383,7 @@ export const TEAM: TeamMember[] = [
 		name: "Jubaka",
 		title: "Developer",
 		core: false,
-		torn: null,
+		torn: 2933938,
 		color: "#7775cf",
 	},
 ];

--- a/src/common/utils/team.ts
+++ b/src/common/utils/team.ts
@@ -379,6 +379,13 @@ export const TEAM: TeamMember[] = [
 		torn: null,
 		color: "#0d9488",
 	},
+	{
+		name: "Jubaka",
+		title: "Developer",
+		core: false,
+		torn: null,
+		color: "#7775cf",
+	},
 ];
 
 interface Contributor {

--- a/src/extension/assets/changelog.json
+++ b/src/extension/assets/changelog.json
@@ -28,7 +28,8 @@
 					"contributor": "DeKleineKobini"
 				},
 				{ "message": "Avoid the 'Bazaar Market' showing up twice", "contributor": "DeKleineKobini" },
-				{ "message": "Trigger the correct filter section when the ff scouter gauge loads.", "contributor": "DeKleineKobini" }
+				{ "message": "Trigger the correct filter section when the ff scouter gauge loads.", "contributor": "DeKleineKobini" },
+				{ "message": "Fix 'Display Case Worth' not showing due to the worth message attaching to the wrong element.", "contributor": "Jubaka" }
 			],
 			"changes": [
 				{


### PR DESCRIPTION
Jubaka [2933938]

- [ x ] Read `CONTRIBUTING.md`.
- [ x ] Added your name in `src/common/utils/team.ts` file.
- [ x ] Update the unreleased version of `src/extension/assets/changelog.json` file
- [ x ] Bump the versions of all related userscripts

Is this PR:
- [ ] for a new feature ?
- [ x ] an issue fix ?
- [ ] a developer QoL PR ?

Fix a regression where `Display Case Worth` would fail to display because the worth message element was being inserted before itself instead of the `.display-cabinet` container.

**Linked issues:**
None
