### PR TITLE
Add Item Market link to museum item details

### DIFF
--- a/src/common/features/museum-market-link/museum-market-link.css
+++ b/src/common/features/museum-market-link/museum-market-link.css
@@ -1,9 +1,18 @@
 .tt-museum-market-link {
 	display: inline-flex;
 	align-items: center;
+	margin-left: -5px;
 	cursor: pointer;
 }
 
 .tt-museum-market-link:hover {
-	filter: brightness(1.2);
+	opacity: 0.7;
+}
+
+body.dark-mode .tt-museum-market-link .cql-item-market {
+	filter: brightness(0) invert(1);
+}
+
+body:not(.dark-mode) .tt-museum-market-link .cql-item-market {
+	filter: brightness(0);
 }

--- a/src/common/features/museum-market-link/museum-market-link.css
+++ b/src/common/features/museum-market-link/museum-market-link.css
@@ -1,0 +1,9 @@
+.tt-museum-market-link {
+	display: inline-flex;
+	align-items: center;
+	cursor: pointer;
+}
+
+.tt-museum-market-link:hover {
+	filter: brightness(1.2);
+}

--- a/src/common/features/museum-market-link/museum-market-link.ts
+++ b/src/common/features/museum-market-link/museum-market-link.ts
@@ -1,0 +1,119 @@
+import "./museum-market-link.css";
+import { ITEM_RESOLVER } from "@common/utils/context";
+import { settings } from "@common/utils/data/database";
+import { elementBuilder } from "@common/utils/functions/dom";
+import { getPageStatus, isSellable } from "@common/utils/functions/torn";
+import { Feature } from "@features/feature";
+
+let observer: MutationObserver | undefined;
+
+function initialiseMarketLink() {
+	const tabs = document.querySelector("#tabs");
+	if (!tabs) return;
+
+	observer = new MutationObserver(() => showMarketLink());
+	observer.observe(tabs, { childList: true, subtree: true, attributes: true, attributeFilter: ["src"] });
+}
+
+function showMarketLink() {
+	const wrapper = document.querySelector("#tabs .show-item-info");
+	const infoElement = wrapper?.querySelector<HTMLElement>("[class*='itemInfo___']");
+	const image = wrapper?.querySelector<HTMLImageElement>("img");
+	if (!infoElement || !image?.src) return;
+
+	const match = image.src.match(/items\/([0-9]+)\/large.*\.png/i);
+	if (!match) return;
+
+	const id = parseInt(match[1]);
+
+	const existingLink = infoElement.querySelector<HTMLElement>(".tt-museum-market-link");
+	if (existingLink) {
+		if (parseInt(existingLink.dataset.itemId) === id) return;
+
+		removeMarketLink(infoElement);
+	}
+
+	if (!isSellable(id)) return;
+
+	const name = document.querySelector(`.item-wrapper[itemid="${id}"] .coll-item-header`)?.textContent?.trim() || ITEM_RESOLVER.getStaticItem(id)?.name || "";
+	const category = ITEM_RESOLVER.getStaticItem(id)?.type || "";
+
+	const link = elementBuilder({
+		type: "a",
+		class: "tt-museum-market-link",
+		dataset: { itemId: id },
+		href: `https://www.torn.com/page.php?sid=ItemMarket#/market/view=search&itemID=${id}&itemName=${name}&itemType=${category}`,
+		attributes: { title: "Open Item Market" },
+		children: [elementBuilder({ type: "i", class: "cql-item-market" })],
+	});
+
+	if (!fillEmptyPropertySlot(infoElement, link)) {
+		const container = infoElement.querySelector<HTMLElement>("[class*='descriptionWrapper___']") || infoElement;
+		container.appendChild(link);
+	}
+}
+
+function fillEmptyPropertySlot(infoElement: HTMLElement, link: HTMLElement) {
+	const list = infoElement.querySelector<HTMLElement>("[class*='properties___']");
+	const titleTemplate = list?.querySelector<HTMLElement>("[class*='title___']");
+	const valueWrapperTemplate = list?.querySelector<HTMLElement>("[class*='valueWrapper___']");
+	if (!list || !titleTemplate || !valueWrapperTemplate) return false;
+
+	const emptyContainer = Array.from(list.children)
+		.map((row) => row.children[0])
+		.find((container): container is HTMLElement => !!container && container.children.length === 0);
+	if (!emptyContainer) return false;
+
+	const title = titleTemplate.cloneNode(true) as HTMLElement;
+	title.textContent = "Market:";
+
+	const valueWrapper = valueWrapperTemplate.cloneNode(false) as HTMLElement;
+	valueWrapper.appendChild(link);
+
+	emptyContainer.append(title, valueWrapper);
+	return true;
+}
+
+function removeMarketLink(scope: ParentNode = document) {
+	const link = scope.querySelector<HTMLElement>(".tt-museum-market-link");
+	if (!link) return;
+
+	const valueWrapper = link.parentElement;
+	if (valueWrapper?.closest("[class*='properties___']")) {
+		valueWrapper.previousElementSibling?.remove();
+		valueWrapper.remove();
+	} else {
+		link.remove();
+	}
+}
+
+export default class MuseumMarketLinkFeature extends Feature {
+	constructor() {
+		super("Museum Market Link", "museum");
+	}
+
+	precondition() {
+		return getPageStatus().access;
+	}
+
+	isEnabled() {
+		return settings.pages.museum.marketLinks;
+	}
+
+	initialise() {
+		initialiseMarketLink();
+	}
+
+	execute() {
+		showMarketLink();
+	}
+
+	cleanup() {
+		observer?.disconnect();
+		removeMarketLink();
+	}
+
+	storageKeys() {
+		return ["settings.pages.museum.marketLinks"];
+	}
+}

--- a/src/common/features/museum-market-link/museum-market-link.ts
+++ b/src/common/features/museum-market-link/museum-market-link.ts
@@ -11,13 +11,16 @@ function initialiseMarketLink() {
 	const tabs = document.querySelector("#tabs");
 	if (!tabs) return;
 
+	observer?.disconnect();
 	observer = new MutationObserver(() => showMarketLink());
 	observer.observe(tabs, { childList: true, subtree: true, attributes: true, attributeFilter: ["src"] });
+
+	showMarketLink();
 }
 
 function showMarketLink() {
 	const wrapper = document.querySelector("#tabs .show-item-info");
-	const infoElement = wrapper?.querySelector<HTMLElement>("[class*='itemInfo___']");
+	const infoElement = wrapper?.querySelector("[class*='itemInfo___']");
 	const image = wrapper?.querySelector<HTMLImageElement>("img");
 	if (!infoElement || !image?.src) return;
 
@@ -48,26 +51,26 @@ function showMarketLink() {
 	});
 
 	if (!fillEmptyPropertySlot(infoElement, link)) {
-		const container = infoElement.querySelector<HTMLElement>("[class*='descriptionWrapper___']") || infoElement;
+		const container = infoElement.querySelector("[class*='descriptionWrapper___']") || infoElement;
 		container.appendChild(link);
 	}
 }
 
-function fillEmptyPropertySlot(infoElement: HTMLElement, link: HTMLElement) {
-	const list = infoElement.querySelector<HTMLElement>("[class*='properties___']");
-	const titleTemplate = list?.querySelector<HTMLElement>("[class*='title___']");
-	const valueWrapperTemplate = list?.querySelector<HTMLElement>("[class*='valueWrapper___']");
+function fillEmptyPropertySlot(infoElement: Element, link: HTMLElement) {
+	const list = infoElement.querySelector("[class*='properties___']");
+	const titleTemplate = list?.querySelector("[class*='title___']");
+	const valueWrapperTemplate = list?.querySelector("[class*='valueWrapper___']");
 	if (!list || !titleTemplate || !valueWrapperTemplate) return false;
 
 	const emptyContainer = Array.from(list.children)
 		.map((row) => row.children[0])
-		.find((container): container is HTMLElement => !!container && container.children.length === 0);
+		.find((container) => container?.children.length === 0);
 	if (!emptyContainer) return false;
 
-	const title = titleTemplate.cloneNode(true) as HTMLElement;
+	const title = titleTemplate.cloneNode(true);
 	title.textContent = "Market:";
 
-	const valueWrapper = valueWrapperTemplate.cloneNode(false) as HTMLElement;
+	const valueWrapper = valueWrapperTemplate.cloneNode(false);
 	valueWrapper.appendChild(link);
 
 	emptyContainer.append(title, valueWrapper);
@@ -75,7 +78,7 @@ function fillEmptyPropertySlot(infoElement: HTMLElement, link: HTMLElement) {
 }
 
 function removeMarketLink(scope: ParentNode = document) {
-	const link = scope.querySelector<HTMLElement>(".tt-museum-market-link");
+	const link = scope.querySelector(".tt-museum-market-link");
 	if (!link) return;
 
 	const valueWrapper = link.parentElement;
@@ -100,16 +103,14 @@ export default class MuseumMarketLinkFeature extends Feature {
 		return settings.pages.museum.marketLinks;
 	}
 
-	initialise() {
-		initialiseMarketLink();
-	}
-
 	execute() {
-		showMarketLink();
+		initialiseMarketLink();
 	}
 
 	cleanup() {
 		observer?.disconnect();
+		observer = undefined;
+
 		removeMarketLink();
 	}
 

--- a/src/common/utils/data/default-database.ts
+++ b/src/common/utils/data/default-database.ts
@@ -481,6 +481,7 @@ export const DEFAULT_STORAGE = {
 			},
 			museum: {
 				autoFill: new DefaultSetting("boolean", true),
+				marketLinks: new DefaultSetting("boolean", true),
 			},
 			enemies: {
 				filter: new DefaultSetting("boolean", true),

--- a/src/common/utils/team.ts
+++ b/src/common/utils/team.ts
@@ -386,6 +386,13 @@ export const TEAM: TeamMember[] = [
 		torn: 2933938,
 		color: "#7775cf",
 	},
+	{
+		name: "Callz",
+		title: "Developer",
+		core: false,
+		torn: 2188704,
+		color: "#dd88a8",
+	},
 ];
 
 interface Contributor {

--- a/src/extension/assets/changelog.json
+++ b/src/extension/assets/changelog.json
@@ -5,7 +5,6 @@
 		"date": false,
 		"logs": {
 			"features": [
-				{ "message": "Add a link to the Item Market when viewing an item's details on the museum page.", "contributor": "Callz" },
 				{ "message": "Reminder for using your casino refill (disabled by default).", "contributor": "DeKleineKobini" },
 				{
 					"message": "Make faction balances clickable when on the give money page, even for out of faction balances.",
@@ -14,7 +13,8 @@
 				{
 					"message": "Display an alert when giving money from the faction when the player balance doesn't allow it and no other balance matches the amount.",
 					"contributor": "DeKleineKobini"
-				}
+				},
+				{ "message": "Add a link to the Item Market when viewing an item's details on the museum page.", "contributor": "Callz" }
 			],
 			"fixes": [
 				{ "message": "Resolve issues with 'Company Last Action'.", "contributor": "DeKleineKobini" },

--- a/src/extension/assets/changelog.json
+++ b/src/extension/assets/changelog.json
@@ -5,6 +5,7 @@
 		"date": false,
 		"logs": {
 			"features": [
+				{ "message": "Add a link to the Item Market when viewing an item's details on the museum page.", "contributor": "Callz" },
 				{ "message": "Reminder for using your casino refill (disabled by default).", "contributor": "DeKleineKobini" },
 				{
 					"message": "Make faction balances clickable when on the give money page, even for out of faction balances.",

--- a/src/extension/entrypoints/options/components/preferences/preference-search-data.ts
+++ b/src/extension/entrypoints/options/components/preferences/preference-search-data.ts
@@ -292,6 +292,13 @@ export const PREFERENCE_SEARCH_DATA: readonly SearchablePreference[] = [
 	{ path: "settings.pages.missions.hints", label: "Mission hints", group: "qol", section: "information", keywords: ["missions"] },
 	{ path: "settings.pages.missions.rewards", label: "Mission reward information", group: "qol", section: "information", keywords: ["missions"] },
 	{ path: "settings.pages.museum.autoFill", label: "Autofill number of sets in museum", group: "qol", section: "information" },
+	{
+		path: "settings.pages.museum.marketLinks",
+		label: "Show a link to the Item Market when viewing an item's details",
+		group: "qol",
+		section: "information",
+		keywords: ["museum", "market"],
+	},
 	{ path: "settings.pages.api.autoDemo", label: "Automatically show demo content on API page", group: "qol", section: "information" },
 	{ path: "settings.pages.api.autoFillKey", label: "Automatically fill your API key on API page", group: "qol", section: "information" },
 	{

--- a/src/extension/entrypoints/options/components/preferences/qol/InformationSection.svelte
+++ b/src/extension/entrypoints/options/components/preferences/qol/InformationSection.svelte
@@ -60,6 +60,7 @@
 	<PreferenceSectionCard title="Museum">
 		<PreferenceSettingGroup>
 			<StorageSwitch path="settings.pages.museum.autoFill" label="Autofill number of sets in museum" />
+			<StorageSwitch path="settings.pages.museum.marketLinks" label="Show a link to the Item Market when viewing an item's details" />
 		</PreferenceSettingGroup>
 	</PreferenceSectionCard>
 

--- a/src/extension/runtime/script-manager.ts
+++ b/src/extension/runtime/script-manager.ts
@@ -156,6 +156,7 @@ import { MissingFlowersFeature, MissingPlushiesFeature } from "@features/missing
 import MissionHintsFeature from "@features/mission-hints/mission-hints";
 import MissionRewardsFeature from "@features/mission-rewards/mission-rewards";
 import MuseumAutoFillFeature from "@features/museum-auto-fill/museum-auto-fill";
+import MuseumMarketLinkFeature from "@features/museum-market-link/museum-market-link";
 import NoConfirmAbroadBuyFeature from "@features/no-confirm/no-confirm-abroad-buy";
 import NoConfirmItemsFeature from "@features/no-confirm/no-confirm-items";
 import NoConfirmPointsMarketFeature from "@features/no-confirm/no-confirm-points-market";
@@ -340,6 +341,7 @@ export function scriptManager() {
 		FEATURE_MANAGER.registerFeature(new StatsEstimateAbroadFeature());
 	} else if (page === "museum") {
 		FEATURE_MANAGER.registerFeature(new MuseumAutoFillFeature());
+		FEATURE_MANAGER.registerFeature(new MuseumMarketLinkFeature());
 	} else if (page === "item") {
 		setupItemPage();
 		FEATURE_MANAGER.registerFeature(new HideRecycleMessageFeature());


### PR DESCRIPTION
**Torn username and ID:** Callz [2188704]

- [x] Read `CONTRIBUTING.md`.
- [x] Added your name in `src/common/utils/team.ts` file.
- [x] Update the unreleased version of `src/extension/assets/changelog.json` file
- [x] Bump the versions of all related userscripts (N/A - no userscript touches the museum page)

Is this PR:
- [x] for a new feature ?
- [ ] an issue fix ?
- [ ] a developer QoL PR ?

**Purpose of PR:**

Adds an "Item Market" link to the item details popup on the museum page (museum.php), so you can jump straight to that item's market listing while browsing your collection.

The link is inserted into the item's properties grid (next to Buy/Sell/Value/Circ), reusing an empty reserved slot and cloning Torn's own row markup so it matches natively and stays fixed regardless of description length.

New toggle (on by default): Settings → QoL → Museum → "Show a link to the Item Market when viewing an item's details".

**Linked issues:**
None